### PR TITLE
the extension now uses the current url to send the request for atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
         ]
       }
     ],
-    "name": "Intuition"
+    "name": "Intuition",
+    "permissions": [
+      "activeTab"
+    ]
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,18 +1,42 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { useSearchAtomsByUriQuery } from '../queries';
+import { useQueryClient } from "@tanstack/react-query"
+import React, { useEffect, useState } from "react"
+
+import { useSearchAtomsByUriQuery } from "../queries"
 
 function Feed() {
+  const [currentUrl, setCurrentUrl] = useState<string | undefined>(undefined)
+  useQueryClient() // Sets the client for gql queries
 
-  const client = useQueryClient(); // Sets the client for gql queries
+  const getCurrentUrl = async () => {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      lastFocusedWindow: true
+    })
+    console.log(tab.url)
+    return tab.url
+  }
+  const refreshUrl = () => {
+    getCurrentUrl().then((url) => setCurrentUrl(url))
+  }
+  useEffect(() => {
 
-  const { data, isLoading } = useSearchAtomsByUriQuery("", "metamask.io")
+    refreshUrl();
+    chrome.tabs.onUpdated.addListener(() => {
+      refreshUrl();
+    })
+
+    chrome.tabs.onActivated.addListener(() => {
+      refreshUrl();
+    })
+  }, [])
+
+  const { data, isLoading } = useSearchAtomsByUriQuery("", currentUrl)
   return (
     <p>
       Feed page
       {isLoading ? "En train de charger" : JSON.stringify(data)}
     </p>
   )
-
 }
 
-export default Feed;
+export default Feed

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "./**/*.tsx"
   ],
   "compilerOptions": {
+    "jsx": "react",
     "paths": {
       "~*": [
         "./*"


### PR DESCRIPTION
The extension will now show atoms for the current active page of the browser (issue #41) 