### PR TITLE
fix: add IDs to atoms in profile section queries to fix popup functio…

### DIFF
--- a/src/components/ui/PopupAtom.tsx
+++ b/src/components/ui/PopupAtom.tsx
@@ -16,8 +16,7 @@ interface PopupAtomProps {
 }
 
 export const PopupAtom = ({ atom, className }: PopupAtomProps) => {
-  const { id, label, image: propImage, img, instanceId } = atom;
-  const imageToUse = propImage || img;
+  const { id, label, image, instanceId } = atom;
   const uniqueIdRef = useRef<string>(
     instanceId || `${id}-${Math.random().toString(36).substr(2, 9)}`
   );
@@ -81,16 +80,16 @@ export const PopupAtom = ({ atom, className }: PopupAtomProps) => {
           }}
           type="button"
         >
-          {imageToUse && (
-            <img 
-              src={imageToUse}  
-              alt={label} 
-              className="w-5 h-5 rounded-full object-cover"
-              onError={(e) => {
-                e.currentTarget.src = "https://thecosmeticdentalgallery.co.uk/wp-content/uploads/2021/11/gold_fingerprint.png"
-              }}
-            />
-          )}
+          {image && (
+              <img 
+                src={image}  
+                alt={label} 
+                className="w-5 h-5 rounded-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.src = "https://thecosmeticdentalgallery.co.uk/wp-content/uploads/2021/11/gold_fingerprint.png"
+                }}
+              />
+            )}
           <span 
             className="truncate max-w-[200px] overflow-hidden whitespace-nowrap block" 
             title={label}

--- a/src/graphql/src/queries/claims.graphql
+++ b/src/graphql/src/queries/claims.graphql
@@ -10,16 +10,19 @@ query GetClaimsByAddress($address: String) {
       triple {
         id
         subject {
+          id
           label
           image
           type
         }
         predicate {
+          id
           label
           image
           type
         }
         object {
+          id
           label
           image
           type

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -205,28 +205,6 @@
   }
 }
 
-html body .portal-container {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 10000;
-  background-color: #00000000;
-  transition: background-color 0.3s ease-in-out;
-}
-
-html body .portal-container.active,
-html body .portal-container:has(.hover-card-content[data-state="open"]) {
-  background-color: #00000070;
-  transition: background-color 0.3s ease-in-out;
-}
-
-html body .portal-container > * {
-  pointer-events: auto;
-}
-
 html body .hover-card-content {
   opacity: 0;
   transform: translateY(10px) scale(0.98);
@@ -234,7 +212,7 @@ html body .hover-card-content {
 }
 
 html body .hover-card-content[data-state="open"] {
-  z-index: 10000;
+  z-index: 20000;
   background-color: white;
   color: black;
   opacity: 1;


### PR DESCRIPTION
Fixed popup atom behavior in profile section by adding atom IDs to GraphQL queries
This PR addresses an issue where popups weren't working properly in the Profile section. The root cause was that atom IDs were missing in the GetClaimsByAddress GraphQL query, while they were present in other similar queries. Adding these IDs enables proper functioning of the PopupAtom component throughout the application.