### PR TITLE
Feature/atom detail route

### DIFF
--- a/src/components/content.tsx
+++ b/src/components/content.tsx
@@ -15,6 +15,7 @@ import Profile from "~src/pages/Profile"
 import RecentActivity from "~src/pages/RecentActivity"
 import Search from "~src/pages/Search"
 import { AtomSelectionProvider } from "./ui/AtomSelectionContext"
+import AtomDetailPage from "~src/pages/AtomDetailPage"
 
 import Navbar from "./layout/Navbar"
 import NavbarUp from "./layout/NavbarUp"
@@ -76,6 +77,7 @@ const Content = ({ children }: ContentProps) => {
                 <Route path="/page-form" element={<PageForm />} />
                 <Route path="/recent-activity" element={<RecentActivity />} />
                 <Route path="/search" element={<Search />} />
+                <Route path="/atoms/:id" element={<AtomDetailPage />} />
               </Routes>
             </div>
           </main>

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -1,27 +1,30 @@
-import React from 'react';
+import React from "react"
+import { Fingerprint } from "lucide-react"
 
-interface ImageWithFallbackProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  fallbackSrc?: string;
-}
+interface ImageWithFallbackProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
 
 export const ImageWithFallback = ({
   src,
   alt = '',
-  fallbackSrc = "https://thecosmeticdentalgallery.co.uk/wp-content/uploads/2021/11/gold_fingerprint.png",
   className,
   ...props
 }: ImageWithFallbackProps) => {
-  const [error, setError] = React.useState(false);
+  const [error, setError] = React.useState(false)
+
+  if (error) {
+    return <Fingerprint className={className} />
+  }
 
   return (
     <img
-      src={error ? fallbackSrc : src}
+      src={src}
       alt={alt}
       className={className}
       onError={() => setError(true)}
       {...props}
     />
-  );
-};
+  )
+}
+
 
 export default ImageWithFallback;

--- a/src/components/ui/PopupAtom.tsx
+++ b/src/components/ui/PopupAtom.tsx
@@ -1,155 +1,119 @@
-import React, { useRef, useId } from 'react'
+import React, { useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+
 import { HoverCard, HoverCardTrigger, HoverCardContent } from './HoverCard'
 import { useGetAtomQuery } from "@0xintuition/graphql"
-import { useOnClickOutside } from '~src/hooks/useOnClickOutside'
 import { ImageWithFallback } from './ImageWithFallback'
 import { useAtomInteraction } from '~src/hooks/useAtomInteraction'
+import { Fingerprint } from "lucide-react"
+
 
 interface PopupAtomProps {
   atom: {
     id: string
     label: string
     image?: string
-    instanceId?: string
   }
 }
 
 export const PopupAtom = ({ atom }: PopupAtomProps) => {
-  const { id, label, image, instanceId } = atom;
-  
-  const uniqueId = useId();
-  const uniqueInstanceId = instanceId || `${id}-${uniqueId}`;
-  
+  const { id, label, image } = atom;
   const atomRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
   const { data, isLoading, error } = useGetAtomQuery({ id });
-  
-  const { 
-    isSelected, 
-    setIsHovered, 
-    handleClick, 
-    isOpen, 
-    setSelectedAtomId 
-  } = useAtomInteraction(uniqueInstanceId);
+  const { isHovered, setIsHovered, isOpen } = useAtomInteraction()
 
-  useOnClickOutside(atomRef, () => {
-    if (isSelected) {
-      setSelectedAtomId(null);
-    }
-  });
+  const goToAtomPage = () => {
+    navigate(`/atoms/${id}`)
+  };
 
-  const renderAtomImage = () => {
-    if (!image) return null;
-    
-    return (
-      <ImageWithFallback 
-        src={image}  
-        alt={label} 
-        className="w-5 h-5 rounded-full object-cover"
+  const renderAtomImage = () => (
+    <ImageWithFallback
+      src={image}
+      alt={label}
+      className="w-5 h-5 rounded-full object-cover"
+    />
+  )  
+
+  const renderAtomDetail = () =>
+    data?.atom?.image ? (
+      <ImageWithFallback
+        src={data.atom.image}
+        alt={data.atom.label || ""}
+        className="w-12 h-12 rounded-full object-cover"
       />
-    );
-  };
+    ) : null
 
-  const renderAtomDetail = () => {
-    if (data?.atom?.image) {
-      return (
-        <ImageWithFallback 
-          src={data.atom.image} 
-          alt={data.atom.label || ''} 
-          className="w-12 h-12 rounded-full object-cover"
-        />
-      );
-    }
-    return null;
-  };
-
-  const renderAtomDescription = () => {
-    if (data?.atom?.value?.thing?.description) {
-      return (
+    const renderAtomDescription = () =>
+      data?.atom?.value?.thing?.description ? (
         <p className="text-sm text-muted-foreground mt-2">
           {data.atom.value.thing.description}
         </p>
-      );
-    }
-    return null;
-  };
+      ) : null
 
-  const renderVaultInfo = () => {
-    if (data?.atom?.vault) {
-      return (
+    const renderVaultInfo = () =>
+      data?.atom?.vault ? (
         <div className="mt-2 text-sm">
           <span className="text-muted-foreground">Positions: </span>
           <span className="font-medium">{data.atom.vault.position_count}</span>
         </div>
-      );
-    }
-    return null;
-  };
+      ) : null
+    
 
-  const renderCardContent = () => {
-    if (isLoading) {
-      return <div className="p-4">Chargement...</div>;
-    }
-    
-    if (error) {
-      return <div className="p-4 text-red-500">Erreur de chargement</div>;
-    }
-    
-    if (!data?.atom) {
-      return <div className="p-4">Aucune information disponible</div>;
-    }
-    
-    return (
-      <div className="flex flex-col gap-2 p-4">
-        {renderAtomDetail()}
-        <div>
-          <h3 className="font-medium text-lg">{data.atom.label}</h3>
-          {renderAtomDescription()}
-          {renderVaultInfo()}
+    const renderCardContent = () => {
+      if (isLoading) return <div className="p-4">Chargement...</div>
+      if (error) return <div className="p-4 text-red-500">Erreur de chargement</div>
+      if (!data?.atom) return <div className="p-4">Aucune information disponible</div>
+  
+      return (
+        <div className="flex flex-col gap-2 p-4">
+          {renderAtomDetail()}
+          <div>
+            <h3 className="font-medium text-lg">{data.atom.label}</h3>
+            {renderAtomDescription()}
+            {renderVaultInfo()}
+          </div>
         </div>
-      </div>
-    );
-  };
-
-  return (
-    <div ref={atomRef} className="relative">
-      <HoverCard 
-        open={isOpen}
-        onOpenChange={(open) => {
-          if (!isSelected) {
-            setIsHovered(open);
-          }
-        }}
-      >
-        <HoverCardTrigger 
-          asChild
-          isAtomTrigger={true}
-          isSelected={isSelected}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+      )
+    }
+  
+    return (
+      <div ref={atomRef} className="relative">
+        <HoverCard
+          open={isOpen}
+          onOpenChange={setIsHovered}
         >
-          <button 
-            onClick={handleClick}
-            type="button"
+          <HoverCardTrigger
+            asChild
+            isAtomTrigger
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
           >
-            {renderAtomImage()}
-            <span 
-              className="truncate max-w-[200px] overflow-hidden whitespace-nowrap block" 
-              title={label}
+            <button
+              type="button"
+              onClick={goToAtomPage}
+              className="flex items-center gap-1"
             >
-              {label}
-            </span>
-          </button>
-        </HoverCardTrigger>
-
-        <HoverCardContent 
-          className="w-80 bg-background border border-border shadow-lg rounded-lg"
-          triggerRef={atomRef}
-        >
-          {renderCardContent()}
-        </HoverCardContent>
-      </HoverCard>
-    </div>
-  );
-};
-
-export default PopupAtom
+              {renderAtomImage()}
+              <span
+                className="truncate max-w-[200px] overflow-hidden whitespace-nowrap block"
+                title={label}
+              >
+                {label}
+              </span>
+            </button>
+          </HoverCardTrigger>
+  
+          <HoverCardContent
+            className="w-80 bg-background border border-border shadow-lg rounded-lg"
+            triggerRef={atomRef}
+          >
+            {renderCardContent()}
+          </HoverCardContent>
+        </HoverCard>
+      </div>
+    )
+  }
+  
+  export default PopupAtom;

--- a/src/hooks/useAtomInteraction.ts
+++ b/src/hooks/useAtomInteraction.ts
@@ -1,30 +1,12 @@
 import { useState } from 'react';
-import { useAtomSelection } from '~/src/components/ui/AtomSelectionContext';
 
-export function useAtomInteraction(uniqueInstanceId: string) {
-  const { selectedAtomId, setSelectedAtomId } = useAtomSelection();
+export function useAtomInteraction() {
   const [isHovered, setIsHovered] = useState(false);
-  
-  const isSelected = selectedAtomId === uniqueInstanceId;
-  
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    
-    if (isSelected) {
-      setSelectedAtomId(null);
-      return;
-    }
-    
-    setSelectedAtomId(uniqueInstanceId);
-  };
-  
+
   return {
-    isSelected,
     isHovered,
     setIsHovered,
-    handleClick,
-    isOpen: isSelected || isHovered,
-    setSelectedAtomId
+    isOpen: isHovered,
   };
 }
 

--- a/src/pages/AtomDetailPage.tsx
+++ b/src/pages/AtomDetailPage.tsx
@@ -1,10 +1,13 @@
 import React from "react"
+import { useParams } from "react-router-dom"
 
 const AtomDetailPage = () => {
+  const { id } = useParams()
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold">Atom details page</h1>
-      <p>Coming soon...</p>
+      <p className="mt-2">Atom ID: {id}</p>
     </div>
   )
 }

--- a/src/pages/AtomDetailPage.tsx
+++ b/src/pages/AtomDetailPage.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+
+const AtomDetailPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Atom details page</h1>
+      <p>Coming soon...</p>
+    </div>
+  )
+}
+
+export default AtomDetailPage;


### PR DESCRIPTION
- A new route /atoms/:id to display atom details.
- A refactor of the PopupAtom component to allow navigation on click.
- A Fingerprint icon fallback when an atom has no image.
- A simplified useAtomInteraction hook, removing unused selection logic.
