### PR TITLE
Fix pointer events in particles canvas

### DIFF
--- a/src/components/ParticlesCanvas.tsx
+++ b/src/components/ParticlesCanvas.tsx
@@ -156,8 +156,8 @@ const ParticlesCanvas: React.FC = () => {
     
     // Configure the events
     window.addEventListener("resize", handleResize)
-    canvas.addEventListener("mousemove", handleMouseMove)
-    canvas.addEventListener("click", handleClick)
+    window.addEventListener("mousemove", handleMouseMove)
+    window.addEventListener("click", handleClick)
     
     // Initialize and start the animation
     handleResize()
@@ -165,13 +165,13 @@ const ParticlesCanvas: React.FC = () => {
     
     // Cleaning
     return () => {
-      window.removeEventListener("resize", handleResize)
-      canvas.removeEventListener("mousemove", handleMouseMove)
-      canvas.removeEventListener("click", handleClick)
-      if (animationFrameId.current) {
-        cancelAnimationFrame(animationFrameId.current)
+        window.removeEventListener("resize", handleResize)
+        window.removeEventListener("mousemove", handleMouseMove)
+        window.removeEventListener("click", handleClick)
+        if (animationFrameId.current) {
+          cancelAnimationFrame(animationFrameId.current)
+        }
       }
-    }
   }, [theme]) // Add theme as a dependency so that the effect is reinitialized when the theme changes
 
   return (

--- a/src/styles/particles-canvas.css
+++ b/src/styles/particles-canvas.css
@@ -14,6 +14,6 @@
     position: absolute;
     top: 0;
     left: 0;
-    pointer-events: auto;
+    pointer-events: none;
     background-color: transparent;
   }


### PR DESCRIPTION
Fix pointer events in particles canvas

- Change event listeners to attach to window instead of canvas
- Keep pointer-events: none in CSS to allow clicks to pass through
- Maintain mouse tracking and visual effects while ensuring UI components remain clickable
- Fix buttons not responding in forms while particles animation is active