### PR TITLE
Feature/atom form bg input

### DIFF
--- a/src/components/AtomAutocompleteInput.tsx
+++ b/src/components/AtomAutocompleteInput.tsx
@@ -89,7 +89,7 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
           setSelectedAtom(null);
           setIsOpen(true);
         }}
-        className="w-full border p-2 rounded"
+        className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10"
         onFocus={() => setIsOpen(true)}
       />
       {isOpen && atoms.length > 0 && (

--- a/src/components/AtomCard.tsx
+++ b/src/components/AtomCard.tsx
@@ -43,7 +43,7 @@ export const AtomCard: React.FC<AtomCardProps> = ({ atom }) => {
   const thing = atom.value?.thing
 
   return (
-    <div className="border border-border-atom rounded-xl p-4 my-2 claims-hover-effect transition-all duration-200">
+    <div className="border border-border-atom rounded-xl p-4 my-2 claims-hover-effect transition-all duration-200 bg-[hsl(var(--claims-bg))]">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           {atom.image ? (

--- a/src/components/AtomForm.tsx
+++ b/src/components/AtomForm.tsx
@@ -135,7 +135,7 @@ const AtomForm: React.FC = () => {
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
+          className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10 relative z-10"
           required
         />
       </div>
@@ -148,7 +148,7 @@ const AtomForm: React.FC = () => {
           id="description"
           value={description}
           onChange={handleDescriptionChange}
-          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded resize-none overflow-hidden"
+          className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10 resize-none overflow-hidden relative z-10"
           rows={1}
         />
       </div>
@@ -161,7 +161,7 @@ const AtomForm: React.FC = () => {
           type="url"
           value={image}
           onChange={(e) => setImage(e.target.value)}
-          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
+          className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10 relative z-10"
         />
         {image && (
           <div className="mt-2">
@@ -180,13 +180,13 @@ const AtomForm: React.FC = () => {
         type="text"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
-        className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
+        className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10 relative z-10"
       />
-
+      
       <button
         type="submit"
         disabled={isSubmitting}
-        className="w-full px-4 py-2 bg-background text-foreground hover:bg-accent hover:text-accent-foreground rounded">
+        className="w-full px-4 py-2 text-foreground btn-atom-form-hover-effect rounded bg-[hsl(var(--btn-atom-form-bg))]">
         {isSubmitting ? "Submitting..." : "Create Atom"}
       </button>
       {progressMessage && (

--- a/src/components/AtomForm.tsx
+++ b/src/components/AtomForm.tsx
@@ -135,7 +135,7 @@ const AtomForm: React.FC = () => {
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full p-2 border rounded"
+          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
           required
         />
       </div>
@@ -148,7 +148,7 @@ const AtomForm: React.FC = () => {
           id="description"
           value={description}
           onChange={handleDescriptionChange}
-          className="w-full p-2 border rounded resize-none overflow-hidden"
+          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded resize-none overflow-hidden"
           rows={1}
         />
       </div>
@@ -161,7 +161,7 @@ const AtomForm: React.FC = () => {
           type="url"
           value={image}
           onChange={(e) => setImage(e.target.value)}
-          className="w-full p-2 border rounded"
+          className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
         />
         {image && (
           <div className="mt-2">
@@ -180,7 +180,7 @@ const AtomForm: React.FC = () => {
         type="text"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
-        className="w-full p-2 border rounded"
+        className="w-full p-2 bg-[hsl(var(--claims-bg))] rounded"
       />
 
       <button

--- a/src/components/LinkTypeSelector.tsx
+++ b/src/components/LinkTypeSelector.tsx
@@ -8,7 +8,7 @@ export const LinkTypeSelector = ({
   setLinkType: (type: "url" | "domain") => void
 }) => (
   <div className="relative max-w-sm flex w-full flex-col rounded-xl shadow mx-auto">
-    <div className="flex flex-row gap-8 p-2 bg-[hsl(var(--claims-bg))] justify-center rounded-xl">
+    <div className="flex flex-row gap-8 p-2 bg-[hsl(var(--btn-atom-form-bg))] justify-center rounded-xl btn-atom-form-hover-effect">
       <div
         role="button"
         className="w-full px-4 py-1 bg-background text-foreground rounded hover:bg-[hsl(var(--accent))] text-center"

--- a/src/components/TripleForm.tsx
+++ b/src/components/TripleForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import AtomAutocompleteInput from './AtomAutocompleteInput'
 import { useCreateTriples } from '~src/hooks/useCreateTriples'
 
@@ -131,7 +131,7 @@ const TripleForm: React.FC = () => {
           <button
             type="button"
             onClick={handleAddTriple}
-            className="px-4 py-2 bg-background text-foreground rounded hover:bg-[hsl(var(--accent))] text-center"
+            className="w-20 px-4 py-2 btn-atom-form-hover-effect text-foreground bg-[hsl(var(--btn-atom-form-bg))] text-center rounded-xl"
           >
             Add
           </button>
@@ -140,7 +140,7 @@ const TripleForm: React.FC = () => {
             type="button"
             onClick={handleSubmitAll}
             disabled={isLoading}
-            className="px-4 py-2 bg-background text-foreground rounded hover:bg-[hsl(var(--accent))] text-center"
+            className="w-20 px-4 py-2 btn-atom-form-hover-effect text-foreground bg-[hsl(var(--btn-atom-form-bg))] text-center rounded-xl"
           >
             {isLoading ? "Send..." : triples.length > 1 ? "Submit all triples" : "Submit"}
           </button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,7 +30,7 @@
     --border-atom: 0 0% 76%;
     --hover-atom-bg: 0 0% 85%;
     --focus-atom-border: 0 0% 0%;
-    
+    --btn-atom-form-bg: 0 0% 70%;
     --container-background: 0.96 0.004 286.32;
     --triple-background: 0.99 0.004 286.32;
   }
@@ -63,7 +63,7 @@
     --border-atom: 0 0% 24%;  
     --hover-atom-bg: 0 0% 15%; 
     --focus-atom-border: 0 0% 100%; 
-    
+    --btn-atom-form-bg: 0 0% 20%;
     --container-background: 0.05 0.002 0; 
     --triple-background: 0.05 0.002 0;
   }
@@ -220,6 +220,16 @@ html body nav .animate-fade-bg:hover {
   
   .claims-hover-effect:hover {
     @apply opacity-100 transform-gpu scale-[1.1] z-[3];;
+  }
+}
+
+@layer utilities {
+  .btn-atom-form-hover-effect {
+    @apply opacity-70 transition-all duration-100 ease-in-out relative z-[1];
+  }
+  
+  .btn-atom-form-hover-effect:hover {
+    @apply opacity-100 transform-gpu z-[3];;
   }
 }
 


### PR DESCRIPTION
## Changes
- Fixed input background opacity issue caused by ParticlesCanvas z-index interference
- Standardized button sizes in AtomForm to match TripleForm
- Added relative z-index to form inputs for proper layering
- Maintained form background transparency while ensuring input visibility

## Technical Details
- Added `z-10` to input elements to prevent ParticlesCanvas overlay
- Updated button classes to use consistent width and styling
- Preserved existing form structure while improving visual consistency

## Visual Changes
- Inputs now have consistent opacity across all forms
- Add and Submit buttons are now the same size
- Form maintains its clean look while being more readable