### PR TITLE
Fix: fallback display when atom has no image on ClaimRowLite component #191

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intuition-chrome-extension",
   "displayName": "Intuition Chrome Extension",
 
-  "version": "0.1.5",
+  "version": "0.1.6",
 
   "description": "",
   "author": "THP-Lab.org",

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -11,8 +11,8 @@ export const ImageWithFallback = ({
 }: ImageWithFallbackProps) => {
   const [error, setError] = React.useState(false)
 
-  if (error) {
-    return <Fingerprint className={className} />
+  if (error || !src) {
+    return null
   }
 
   return (

--- a/src/components/ui/PopupAtom.tsx
+++ b/src/components/ui/PopupAtom.tsx
@@ -29,13 +29,22 @@ export const PopupAtom = ({ atom }: PopupAtomProps) => {
     navigate(`/atoms/${id}`)
   };
 
-  const renderAtomImage = () => (
-    <ImageWithFallback
-      src={image}
-      alt={label}
-      className="w-5 h-5 rounded-full object-cover"
-    />
-  )  
+  const renderAtomImage = () => {
+    if (image) {
+      return (
+        <ImageWithFallback
+          src={image}
+          alt={label}
+          className="w-5 h-5 rounded-full object-cover"
+        />
+      )
+    }
+    return (
+      <div className="w-5 h-5 flex items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <Fingerprint size={14} />
+      </div>
+    )
+  }
 
   const renderAtomDetail = () =>
     data?.atom?.image ? (
@@ -44,7 +53,11 @@ export const PopupAtom = ({ atom }: PopupAtomProps) => {
         alt={data.atom.label || ""}
         className="w-12 h-12 rounded-full object-cover"
       />
-    ) : null
+    ) : (
+      <div className="w-12 h-12 flex items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <Fingerprint className="w-6 h-6" />
+      </div>
+    )
 
     const renderAtomDescription = () =>
       data?.atom?.value?.thing?.description ? (


### PR DESCRIPTION
ImageWithFallback now returns null on error or missing src. The visua…
The visual fallback (Fingerprint icon) is handled directly in PopupAtom for consistency with other components.