### PR TITLE
Fix bug request fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intuition-chrome-extension",
   "displayName": "Intuition Chrome Extension",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "author": "THP-Lab.org",
   "scripts": {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,7 +11,7 @@ import AtomCard from "~src/components/AtomCard";
 function Home() {
   const { theme } = useTheme()
   const [currentUrl, setCurrentUrl] = useState<string>("")
-  const [walletAddress] = useStorage<string>("metamask-account")
+  const [walletAddress] = useStorage<string>("metamask-account", "")
   const [activeTab, setActiveTab] = useState("Claims")
 
   useQueryClient() 
@@ -28,7 +28,6 @@ function Home() {
     getCurrentUrl().then((url) => setCurrentUrl(url || ""))
   }
   useEffect(() => {
-    console.log("current wallet address:", walletAddress);
     refreshUrl()
     chrome.tabs.onUpdated.addListener(() => {
       refreshUrl()
@@ -41,6 +40,7 @@ function Home() {
 
   const { data, isLoading, error } = useGetClaimsByUriQuery({uri: currentUrl, address: walletAddress })
   const atoms = data?.atoms ?? []
+  console.log("current wallet address:", walletAddress);
 
   const claims = Array.from(
     new Map(

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -41,7 +41,7 @@ const Search: React.FC = () => {
     },
     address: walletAddress
   }, {
-    enabled: !!searchTerm && !!walletAddress
+    enabled: !!searchTerm 
   })
 
   

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -10,7 +10,7 @@ const Search: React.FC = () => {
   const [isSidePanel, setIsSidePanel] = useState(false)
   const [searchTerm, setSearchTerm] = useState("")
   const [activeTab, setActiveTab] = useState("All")
-  const [walletAddress] = useStorage<string>("metamask-account")
+  const [walletAddress] = useStorage<string>("metamask-account", "")
 
   useEffect(() => {
     const checkWidth = () => {


### PR DESCRIPTION
Fixed MetaMask Connection Detection on Home & Search Pages
We fixed a bug where the Home and Search pages were not retrieving personalized vote data linked to the connected MetaMask wallet. This issue caused the GraphQL query to fail or return incomplete data when no wallet was detected initially.

Fixes implemented:
Set a default value ("") for walletAddress using useStorage to prevent it from being undefined.
This ensures a smooth user experience with a fully functional public view even without a connected wallet, while displaying personalized votes as soon as a wallet is detected.

This update unifies the behavior of both pages and improves compatibility with MetaMask connection flow, regardless of the user's login state.