### PR TITLE
Create atom if doesnt exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intuition-chrome-extension",
   "displayName": "Intuition Chrome Extension",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "",
   "author": "THP-Lab.org",
   "scripts": {

--- a/src/components/AtomAutocompleteInput.tsx
+++ b/src/components/AtomAutocompleteInput.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useDebounce } from 'use-debounce';
 import { useGetAtomsQuery } from '@0xintuition/graphql';
+import { usePageMetadata } from "../hooks/usePageMetadata"
 import AtomForm from './AtomForm'
+import { Plus } from "lucide-react"
+
 
 interface Atom {
   id: string;
@@ -23,6 +26,8 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
   const [newAtomLabel, setNewAtomLabel] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [creationMode, setCreationMode] = useState<"input" | "page" | null>(null)
+  const pageMeta = usePageMetadata()
 
   const [debouncedSearch] = useDebounce(search, 300);
 
@@ -103,27 +108,41 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
       />
       {isOpen && (
         <ul className="absolute z-10 bg-[hsl(var(--navbar-bg))] text-foreground border border-border rounded w-full max-h-60 overflow-y-auto shadow-md">
-          {atoms.length > 0 && !creatingAtom &&
-            atoms.map((atom) => (
-              <li
-                key={atom.id}
-                className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer"
-                onClick={() => handleSelect(atom)}
-              >
-                {atom.emoji && <span className="mr-2">{atom.emoji}</span>}
-                <span>{atom.label}</span>
-                <span className="text-xs text-muted-foreground ml-2">({atom.id})</span>
-              </li>
-            ))
-          }
-
-          {atoms.length === 0 && !creatingAtom && (
+          {atoms.map((atom) => (
             <li
-              className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer text-sm italic"
-              onClick={() => setCreatingAtom(true)}
+              key={atom.id}
+              className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer"
+              onClick={() => handleSelect(atom)}
             >
-              Create « {search} »
+              {atom.emoji && <span className="mr-2">{atom.emoji}</span>}
+              <span>{atom.label}</span>
+              <span className="text-xs text-muted-foreground ml-2">({atom.id})</span>
             </li>
+          ))}
+
+          { !creatingAtom && (
+            <>
+              <li
+                className="flex items-center gap-2 p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer italic"
+                onClick={() => {
+                  setCreatingAtom(true)
+                  setCreationMode("input")
+                }}
+              >
+                <Plus size={12} />
+                Create new atom « {search} »
+              </li>
+              <li
+                className="flex items-center gap-2 p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer italic"
+                onClick={() => {
+                  setCreatingAtom(true)
+                  setCreationMode("page")
+                }}
+              >
+                <Plus size={12} />
+                Create from current page {pageMeta.title ? `: “${pageMeta.title}”` : ""}
+              </li>
+            </>
           )}
 
           {creatingAtom && (
@@ -132,12 +151,18 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
                 onCreated={(atom) => {
                   handleSelect(atom)
                   setCreatingAtom(false)
+                  setCreationMode(null)
                 }}
-                initialName={newAtomLabel}
+                initialName={
+                  creationMode === "input" ? search :
+                  creationMode === "page" ? pageMeta.title : ""
+                }
+                initialDescription={creationMode === "page" ? pageMeta.description : ""}
+                initialImage={creationMode === "page" ? pageMeta.favicon : ""}
+                initialUrl={creationMode === "page" ? pageMeta.url : ""}
               />
             </li>
           )}
-
         </ul>
       )}
     </div>

--- a/src/components/AtomAutocompleteInput.tsx
+++ b/src/components/AtomAutocompleteInput.tsx
@@ -1,23 +1,26 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useDebounce } from 'use-debounce';
 import { useGetAtomsQuery } from '@0xintuition/graphql';
+import AtomForm from './AtomForm'
 
 interface Atom {
   id: string;
   label?: string | null;
   emoji?: string | null;
-  vault_id: string;  
+  vault_id: string;
 }
 
 interface AtomAutocompleteInputProps {
   label: string;
   onSelect: (atom: Atom) => void;
-  selected: Atom | null;  
+  selected: Atom | null;
 }
 
 const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, onSelect, selected }) => {
   const [search, setSearch] = useState('');
   const [isOpen, setIsOpen] = useState(false);
+  const [creatingAtom, setCreatingAtom] = useState(false);
+  const [newAtomLabel, setNewAtomLabel] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -31,6 +34,7 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
     const handleClickOutside = (event: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
         setIsOpen(false);
+        setCreatingAtom(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -58,17 +62,19 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
     }
   );
 
-  const atoms: Atom[] = data?.atoms.map(atom => ({
-    id: atom.id,
-    label: atom.label,
-    emoji: atom.emoji,
-    vault_id: atom.vault_id,
-  })) || []
+  const atoms: Atom[] =
+    data?.atoms.map(atom => ({
+      id: atom.id,
+      label: atom.label,
+      emoji: atom.emoji,
+      vault_id: atom.vault_id,
+    })) || [];
 
   const handleSelect = (atom: Atom) => {
-    onSelect(atom);         
+    onSelect(atom);
     setIsOpen(false);
-  
+    setCreatingAtom(false);
+
     setTimeout(() => {
       const form = inputRef.current?.form;
       if (!form || !inputRef.current) return;
@@ -88,25 +94,50 @@ const AtomAutocompleteInput: React.FC<AtomAutocompleteInputProps> = ({ label, on
         value={search}
         onChange={(e) => {
           setSearch(e.target.value);
-          setSelectedAtom(null);
+          setNewAtomLabel(e.target.value);
           setIsOpen(true);
+          setCreatingAtom(false);
         }}
         className="w-full p-2 bg-[hsl(var(--navbar-bg))] text-foreground rounded border border-border/10"
         onFocus={() => setIsOpen(true)}
       />
-      {isOpen && atoms.length > 0 && (
+      {isOpen && (
         <ul className="absolute z-10 bg-[hsl(var(--navbar-bg))] text-foreground border border-border rounded w-full max-h-60 overflow-y-auto shadow-md">
-          {atoms.map((atom) => (
+          {atoms.length > 0 && !creatingAtom &&
+            atoms.map((atom) => (
+              <li
+                key={atom.id}
+                className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer"
+                onClick={() => handleSelect(atom)}
+              >
+                {atom.emoji && <span className="mr-2">{atom.emoji}</span>}
+                <span>{atom.label}</span>
+                <span className="text-xs text-muted-foreground ml-2">({atom.id})</span>
+              </li>
+            ))
+          }
+
+          {atoms.length === 0 && !creatingAtom && (
             <li
-              key={atom.id}
-              className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer"
-              onClick={() => handleSelect(atom)}
+              className="p-2 hover:bg-accent hover:text-accent-foreground cursor-pointer text-sm italic"
+              onClick={() => setCreatingAtom(true)}
             >
-              {atom.emoji && <span className="mr-2">{atom.emoji}</span>}
-              <span>{atom.label}</span>
-              <span className="text-xs text-muted-foreground ml-2">({atom.id})</span>
+              Create « {search} »
             </li>
-          ))}
+          )}
+
+          {creatingAtom && (
+            <li className="p-2">
+              <AtomForm
+                onCreated={(atom) => {
+                  handleSelect(atom)
+                  setCreatingAtom(false)
+                }}
+                initialName={newAtomLabel}
+              />
+            </li>
+          )}
+
         </ul>
       )}
     </div>

--- a/src/components/AtomForm.tsx
+++ b/src/components/AtomForm.tsx
@@ -7,10 +7,15 @@ import { LinkTypeSelector } from "./LinkTypeSelector"
 import React, { forwardRef, useEffect, useState, useRef, useImperativeHandle } from "react"
 import { umamiCollect } from "~src/lib/umami"
 
-const AtomForm = forwardRef((_, ref) => {
+interface AtomFormProps {
+  onCreated: (atom: Atom) => void;
+  initialName?: string;
+}
+
+const AtomForm = forwardRef<HTMLFormElement, AtomFormProps>(({ onCreated, initialName = "" }, ref) => {
   const { mutateAsync: pinThing } = usePinThingMutation()
 
-  const [name, setName] = useState("")
+  const [name, setName] = useState(initialName)
   const [description, setDescription] = useState("")
   const [image, setImage] = useState("")
   const [url, setUrl] = useState("")
@@ -35,7 +40,6 @@ const AtomForm = forwardRef((_, ref) => {
       setProgressMessage(null)
       setErrorMessage(null)
       setIsSubmitting(false)
-
       descriptionRef.current?.style.setProperty("height", "auto")
     }
   }))
@@ -144,6 +148,14 @@ const AtomForm = forwardRef((_, ref) => {
       })
       setProgressMessage(` Atom créé ! Vault ID: ${vaultId} | Tx: ${hash}`)
       
+      const atom = {
+        id: hash, // ou autre identifiant temporaire si hash ≠ id
+        label: name,
+        emoji: null,
+        vault_id: vaultId.toString(),
+      }
+      onCreated(atom)
+
       umamiCollect("atom_created", "/sidepanel", {
         vaultId,
         txHash: hash
@@ -219,7 +231,7 @@ const AtomForm = forwardRef((_, ref) => {
       />
       
       <button
-        type="submit"
+        onClick={handleSubmit}
         disabled={isSubmitting}
         className="w-full px-4 py-2 text-foreground btn-atom-form-hover-effect rounded bg-[hsl(var(--btn-atom-form-bg))]">
         {isSubmitting ? "Submitting..." : "Create Atom"}

--- a/src/components/AtomForm.tsx
+++ b/src/components/AtomForm.tsx
@@ -10,16 +10,20 @@ import { umamiCollect } from "~src/lib/umami"
 interface AtomFormProps {
   onCreated: (atom: Atom) => void;
   initialName?: string;
+  initialDescription?: string;
+  initialImage?: string;
+  initialUrl?: string;
 }
 
-const AtomForm = forwardRef<HTMLFormElement, AtomFormProps>(({ onCreated, initialName = "" }, ref) => {
+const AtomForm = forwardRef<HTMLFormElement, AtomFormProps>(({ onCreated, initialName = "", initialDescription = "", initialImage = "", initialUrl = "" }, ref) => {
   const { mutateAsync: pinThing } = usePinThingMutation()
 
-  const [name, setName] = useState(initialName)
-  const [description, setDescription] = useState("")
-  const [image, setImage] = useState("")
-  const [url, setUrl] = useState("")
-  const [rawUrl, setRawUrl] = useState("")
+  const [name, setName] = useState(initialName ?? "")
+  const [description, setDescription] = useState(initialDescription ?? "")
+  const [image, setImage] = useState(initialImage ?? "")
+  const [url, setUrl] = useState(initialUrl ?? "")
+  
+  const [rawUrl] = useState(initialUrl ?? "")
 
   const [progressMessage, setProgressMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -50,68 +54,22 @@ const AtomForm = forwardRef<HTMLFormElement, AtomFormProps>(({ onCreated, initia
     e.target.style.height = e.target.scrollHeight + "px"
   }
   
-
   useEffect(() => {
-    const fetchPageDetails = async () => {
-      if (initialUrlCaptured) return
-
-      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
-      if (!tab?.id || !tab.url) return
-      if (tab.url.startsWith("chrome-extension://")) return
-
-      const pageUrl = tab.url
-      setRawUrl(pageUrl)
-      setUrl(linkType === "url" ? pageUrl : new URL(pageUrl).hostname)
-
-      setInitialUrlCaptured(true)
-      
-      chrome.scripting.executeScript(
-        {
-          target: { tabId: tab.id },
-          func: () => {
-            const getMeta = (name: string) =>
-              document.querySelector(`meta[name="${name}"]`)?.getAttribute("content")
-
-            return {
-              title: document.title,
-              description: getMeta("description") || "",
-              favicon: [...document.querySelectorAll("link[rel~='icon']")]
-                .map((el) => (el as HTMLLinkElement).href)[0] || ""
-            }
-          }
-        },
-        (results) => {
-          const result = results?.[0]?.result
-          if (result) {
-            setName(result.title || "")
-            setDescription(result.description || "")
-            setImage(result.favicon || "")
-          
-            setTimeout(() => {
-              if (descriptionRef.current) {
-                descriptionRef.current.style.height = "auto"
-                descriptionRef.current.style.height = descriptionRef.current.scrollHeight + "px"
-              }
-            }, 0)
-          }
-        }
-      )
+    if (descriptionRef.current) {
+      descriptionRef.current.style.height = "auto"
+      descriptionRef.current.style.height = `${descriptionRef.current.scrollHeight}px`
     }
-
-    fetchPageDetails()
-
-    chrome.tabs.onUpdated.addListener(fetchPageDetails)
-    chrome.tabs.onActivated.addListener(fetchPageDetails)
+  }, [description])
   
-    return () => {
-      chrome.tabs.onUpdated.removeListener(fetchPageDetails)
-      chrome.tabs.onActivated.removeListener(fetchPageDetails)
-    }
-  }, [linkType])
-
   useEffect(() => {
     if (!rawUrl) return
-    setUrl(linkType === "url" ? rawUrl : new URL(rawUrl).hostname)
+    try {
+      const parsed = new URL(rawUrl)
+      const formatted = linkType === "url" ? parsed.href : parsed.hostname
+      setUrl(formatted)
+    } catch (err) {
+      setUrl(rawUrl) 
+    }
   }, [linkType, rawUrl])
 
   async function handleSubmit(e: React.FormEvent) {

--- a/src/hooks/usePageMetadata.ts
+++ b/src/hooks/usePageMetadata.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react"
+
+type PageMetadata = {
+  title: string
+  description: string
+  favicon: string
+  url: string
+}
+
+export function usePageMetadata(): PageMetadata {
+  const [meta, setMeta] = useState<PageMetadata>({
+    title: "",
+    description: "",
+    favicon: "",
+    url: ""
+  })
+
+  useEffect(() => {
+    const fetchPageDetails = async () => {
+      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
+      if (!tab?.id || !tab.url || tab.url.startsWith("chrome-extension://")) return
+
+      const pageUrl = tab.url
+
+      chrome.scripting.executeScript(
+        {
+          target: { tabId: tab.id },
+          func: () => {
+            const getMeta = (name: string) =>
+              document.querySelector(`meta[name="${name}"]`)?.getAttribute("content")
+
+            return {
+              title: document.title,
+              description: getMeta("description") || "",
+              favicon: [...document.querySelectorAll("link[rel~='icon']")]
+                .map((el) => el.href)[0] || ""
+            }
+          }
+        },
+        (results) => {
+          const result = results?.[0]?.result
+          if (result) {
+            setMeta({
+              title: result.title,
+              description: result.description,
+              favicon: result.favicon,
+              url: pageUrl
+            })
+          }
+        }
+      )
+    }
+
+    fetchPageDetails()
+  
+    chrome.tabs.onUpdated.addListener(fetchPageDetails)
+    chrome.tabs.onActivated.addListener(fetchPageDetails)
+  
+    return () => {
+      chrome.tabs.onUpdated.removeListener(fetchPageDetails)
+      chrome.tabs.onActivated.removeListener(fetchPageDetails)
+    }
+  }, [])
+
+  return meta
+}

--- a/src/pages/PageForm.tsx
+++ b/src/pages/PageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react"
+import React, { useState, useRef } from "react"
 import * as Switch from "@radix-ui/react-switch"
 import { RefreshCw } from 'lucide-react';
 

--- a/src/pages/PageForm.tsx
+++ b/src/pages/PageForm.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useRef } from "react"
+import React, { useState, useRef, useEffect } from "react"
 import * as Switch from "@radix-ui/react-switch"
 import { RefreshCw } from 'lucide-react';
 
 import AtomForm from "../components/AtomForm"
 import TripleForm from "../components/TripleForm"
+import { usePageMetadata } from "../hooks/usePageMetadata"
 
 function PageForm() {
   const [showTripleForm, setShowTripleForm] = useState(false)
 
   const atomFormRef = useRef(null)
   const tripleFormRef = useRef(null)
+  const meta = usePageMetadata()
 
   const handleResetForms = () => {
     if (showTripleForm && tripleFormRef.current?.resetForm) {
@@ -53,7 +55,14 @@ function PageForm() {
   {showTripleForm ? (
     <TripleForm ref={tripleFormRef} />
   ) : (
-    <AtomForm ref={atomFormRef} />
+    <AtomForm
+      key={meta.url || "default"}
+      ref={atomFormRef}
+      initialName={meta.title}
+      initialDescription={meta.description}
+      initialImage={meta.favicon}
+      initialUrl={meta.url}
+    />
   )}
 </div>
   )


### PR DESCRIPTION

## Main changes:

- **Added two atom creation options** in the autocomplete
- **Display creation options even when matching atoms exist**, shown at the bottom of the suggestion list.

## Refactoring `AtomForm`:

- **Moved the `fetchPageDetails` logic** out of `AtomForm` into `PageForm`, using a custom hook `usePageMetadata()`.
- **Proper synchronization of input fields** (`name`, `description`, etc.) based on the initial props received.
