### PR TITLE
Fix bug url form atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intuition-chrome-extension",
   "displayName": "Intuition Chrome Extension",
 
-  "version": "0.1.29",
+  "version": "0.1.32",
 
   "description": "",
   "author": "THP-Lab.org",

--- a/src/components/AtomForm.tsx
+++ b/src/components/AtomForm.tsx
@@ -69,15 +69,22 @@ const AtomForm = forwardRef<AtomFormHandle, AtomFormProps>(function AtomForm(
   }, [description])
   
   useEffect(() => {
-    if (!rawUrl) return
+    if (!rawUrl) return;
+
     try {
-      const parsed = new URL(rawUrl)
-      const formatted = linkType === "url" ? parsed.href : parsed.hostname
-      setUrl(formatted)
-    } catch (err) {
-      setUrl(rawUrl) 
+      const input = /^https?:\/\//i.test(rawUrl) ? rawUrl : `https://${rawUrl}`;
+      const parsed = new URL(input);
+
+      if (linkType === "domain") {
+        setUrl(`https://${parsed.hostname}/`);
+      } else {
+        setUrl(parsed.href);
+      }
+    } catch {
+      setUrl(rawUrl);
     }
-  }, [linkType, rawUrl])
+  }, [rawUrl, linkType]);
+
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()


### PR DESCRIPTION
I added https/: to the domain name because without it, the domain doesn't provide direct access to the website.
This ensures the link works properly when viewed.