### PR TITLE
feat:wallet connection in feed page for better UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intuition-chrome-extension",
   "displayName": "Intuition Chrome Extension",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "",
   "author": "THP-Lab.org",
   "scripts": {

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import ClaimRowLite from "~src/components/ui/ClaimRowLite"
 import { useStorage } from "@plasmohq/storage/dist/hook"
 import { useGetFollowingsFromAddressQuery } from "~src/graphql/src"
+import WalletConnectionButton from "~src/components/WalletConnectionButton"
 
 function Feed() {
   const [walletAddress] = useStorage<string>("metamask-account")
@@ -14,7 +15,14 @@ function Feed() {
   const default_img =
     "https://i.seadn.io/gae/PWDq8erM2dMscd99OntjFRJFfvtvki7uxeYiBUT8e59Kdbn8s34dM59kCkVZ66b687B6i8KXMDspRfnU-JbLcB9Kc23EoSydJNkmgA?auto=format&dpr=1&w=1000"
 
-  if (!walletAddress) return <p>Connect your wallet</p>
+if (!walletAddress) {
+    return (
+      <div className="flex flex-col justify-center items-center">
+        <p>Please connect your wallet</p>
+        <WalletConnectionButton />
+      </div>
+    )
+  }
   if (isLoading) return <p>Loading who you follow...</p>
   if (isError) return <p>Error loading followings</p>
 


### PR DESCRIPTION
Added a connection to wallet button directly in the feed page for better UX because the user was prompted to link their wallet but wasn't indicated how to do it so this add make the navigation smoother for non connected users