### PR TITLE
V1.5/atom display

### DIFF
--- a/src/graphql/src/generated/index.ts
+++ b/src/graphql/src/generated/index.ts
@@ -1,5 +1,15 @@
-import * as Apollo from "@apollo/client"
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  UseInfiniteQueryOptions,
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  UseQueryOptions
+} from "@tanstack/react-query"
 import { DocumentNode } from "graphql"
+
+import { fetcher } from "../client"
 
 export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
@@ -21,7 +31,6 @@ export type Incremental<T> =
   | {
       [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never
     }
-const defaultOptions = {} as const
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: { input: string; output: string }
@@ -533,18 +542,17 @@ export type Accounts_Order_By = {
 }
 
 /** select columns of table "account" */
-export enum Accounts_Select_Column {
+export type Accounts_Select_Column =
   /** column name */
-  AtomId = "atom_id",
+  | "atom_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Image = "image",
+  | "image"
   /** column name */
-  Label = "label",
+  | "label"
   /** column name */
-  Type = "type"
-}
+  | "type"
 
 /** aggregate stddev on columns */
 export type Accounts_Stddev_Fields = {
@@ -813,26 +821,25 @@ export type Atom_Values_Order_By = {
 }
 
 /** select columns of table "atom_value" */
-export enum Atom_Values_Select_Column {
+export type Atom_Values_Select_Column =
   /** column name */
-  AccountId = "account_id",
+  | "account_id"
   /** column name */
-  BookId = "book_id",
+  | "book_id"
   /** column name */
-  ByteObjectId = "byte_object_id",
+  | "byte_object_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  JsonObjectId = "json_object_id",
+  | "json_object_id"
   /** column name */
-  OrganizationId = "organization_id",
+  | "organization_id"
   /** column name */
-  PersonId = "person_id",
+  | "person_id"
   /** column name */
-  TextObjectId = "text_object_id",
+  | "text_object_id"
   /** column name */
-  ThingId = "thing_id"
-}
+  | "thing_id"
 
 /** aggregate stddev on columns */
 export type Atom_Values_Stddev_Fields = {
@@ -1354,32 +1361,31 @@ export type Atoms_Order_By = {
 }
 
 /** select columns of table "atom" */
-export enum Atoms_Select_Column {
+export type Atoms_Select_Column =
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  CreatorId = "creator_id",
+  | "creator_id"
   /** column name */
-  Data = "data",
+  | "data"
   /** column name */
-  Emoji = "emoji",
+  | "emoji"
   /** column name */
-  Image = "image",
+  | "image"
   /** column name */
-  Label = "label",
+  | "label"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TransactionHash = "transaction_hash",
+  | "transaction_hash"
   /** column name */
-  Type = "type",
+  | "type"
   /** column name */
-  ValueId = "value_id",
+  | "value_id"
   /** column name */
-  WalletId = "wallet_id"
-}
+  | "wallet_id"
 
 /** aggregate stddev on columns */
 export type Atoms_Stddev_Fields = {
@@ -1628,18 +1634,17 @@ export type Books_Order_By = {
 }
 
 /** select columns of table "book" */
-export enum Books_Select_Column {
+export type Books_Select_Column =
   /** column name */
-  Description = "description",
+  | "description"
   /** column name */
-  Genre = "genre",
+  | "genre"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Name = "name",
+  | "name"
   /** column name */
-  Url = "url"
-}
+  | "url"
 
 /** aggregate stddev on columns */
 export type Books_Stddev_Fields = {
@@ -1774,12 +1779,11 @@ export type Byte_Object_Order_By = {
 }
 
 /** select columns of table "byte_object" */
-export enum Byte_Object_Select_Column {
+export type Byte_Object_Select_Column =
   /** column name */
-  Data = "data",
+  | "data"
   /** column name */
-  Id = "id"
-}
+  | "id"
 
 /** aggregate stddev on columns */
 export type Byte_Object_Stddev_Fields = {
@@ -1890,20 +1894,19 @@ export type Cached_Images_Cached_Image_Order_By = {
 }
 
 /** select columns of table "cached_images.cached_image" */
-export enum Cached_Images_Cached_Image_Select_Column {
+export type Cached_Images_Cached_Image_Select_Column =
   /** column name */
-  CreatedAt = "created_at",
+  | "created_at"
   /** column name */
-  Model = "model",
+  | "model"
   /** column name */
-  OriginalUrl = "original_url",
+  | "original_url"
   /** column name */
-  Safe = "safe",
+  | "safe"
   /** column name */
-  Score = "score",
+  | "score"
   /** column name */
-  Url = "url"
-}
+  | "url"
 
 /** Streaming cursor of the table "cached_images_cached_image" */
 export type Cached_Images_Cached_Image_Stream_Cursor_Input = {
@@ -2010,16 +2013,15 @@ export type Caip10_Order_By = {
 }
 
 /** select columns of table "caip10" */
-export enum Caip10_Select_Column {
+export type Caip10_Select_Column =
   /** column name */
-  AccountAddress = "account_address",
+  | "account_address"
   /** column name */
-  ChainId = "chain_id",
+  | "chain_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Namespace = "namespace"
-}
+  | "namespace"
 
 /** aggregate stddev on columns */
 export type Caip10_Stddev_Fields = {
@@ -2109,12 +2111,11 @@ export type Chainlink_Prices_Order_By = {
 }
 
 /** select columns of table "chainlink_price" */
-export enum Chainlink_Prices_Select_Column {
+export type Chainlink_Prices_Select_Column =
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Usd = "usd"
-}
+  | "usd"
 
 /** Streaming cursor of the table "chainlink_prices" */
 export type Chainlink_Prices_Stream_Cursor_Input = {
@@ -2237,14 +2238,13 @@ export type Claims_Order_By = {
 }
 
 /** select columns of table "claim" */
-export enum Claims_Select_Column {
+export type Claims_Select_Column =
   /** column name */
-  AccountId = "account_id",
+  | "account_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  PositionId = "position_id"
-}
+  | "position_id"
 
 /** Streaming cursor of the table "claims" */
 export type Claims_Stream_Cursor_Input = {
@@ -2262,12 +2262,11 @@ export type Claims_Stream_Cursor_Value_Input = {
 }
 
 /** ordering argument of a cursor */
-export enum Cursor_Ordering {
+export type Cursor_Ordering =
   /** ascending ordering of the cursor */
-  Asc = "ASC",
+  | "ASC"
   /** descending ordering of the cursor */
-  Desc = "DESC"
-}
+  | "DESC"
 
 /** columns and relationships of "deposit" */
 export type Deposits = {
@@ -2506,52 +2505,49 @@ export type Deposits_Order_By = {
 }
 
 /** select columns of table "deposit" */
-export enum Deposits_Select_Column {
+export type Deposits_Select_Column =
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  CurveId = "curve_id",
+  | "curve_id"
   /** column name */
-  EntryFee = "entry_fee",
+  | "entry_fee"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  IsAtomWallet = "is_atom_wallet",
+  | "is_atom_wallet"
   /** column name */
-  IsTriple = "is_triple",
+  | "is_triple"
   /** column name */
-  ReceiverId = "receiver_id",
+  | "receiver_id"
   /** column name */
-  ReceiverTotalSharesInVault = "receiver_total_shares_in_vault",
+  | "receiver_total_shares_in_vault"
   /** column name */
-  SenderAssetsAfterTotalFees = "sender_assets_after_total_fees",
+  | "sender_assets_after_total_fees"
   /** column name */
-  SenderId = "sender_id",
+  | "sender_id"
   /** column name */
-  SharesForReceiver = "shares_for_receiver",
+  | "shares_for_receiver"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TransactionHash = "transaction_hash"
-}
+  | "transaction_hash"
 
 /** select "deposits_aggregate_bool_exp_bool_and_arguments_columns" columns of table "deposit" */
-export enum Deposits_Select_Column_Deposits_Aggregate_Bool_Exp_Bool_And_Arguments_Columns {
+export type Deposits_Select_Column_Deposits_Aggregate_Bool_Exp_Bool_And_Arguments_Columns =
   /** column name */
-  IsAtomWallet = "is_atom_wallet",
+  | "is_atom_wallet"
   /** column name */
-  IsTriple = "is_triple"
-}
+  | "is_triple"
 
 /** select "deposits_aggregate_bool_exp_bool_or_arguments_columns" columns of table "deposit" */
-export enum Deposits_Select_Column_Deposits_Aggregate_Bool_Exp_Bool_Or_Arguments_Columns {
+export type Deposits_Select_Column_Deposits_Aggregate_Bool_Exp_Bool_Or_Arguments_Columns =
   /** column name */
-  IsAtomWallet = "is_atom_wallet",
+  | "is_atom_wallet"
   /** column name */
-  IsTriple = "is_triple"
-}
+  | "is_triple"
 
 /** aggregate stddev on columns */
 export type Deposits_Stddev_Fields = {
@@ -2902,28 +2898,27 @@ export type Events_Order_By = {
 }
 
 /** select columns of table "event" */
-export enum Events_Select_Column {
+export type Events_Select_Column =
   /** column name */
-  AtomId = "atom_id",
+  | "atom_id"
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  DepositId = "deposit_id",
+  | "deposit_id"
   /** column name */
-  FeeTransferId = "fee_transfer_id",
+  | "fee_transfer_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  RedemptionId = "redemption_id",
+  | "redemption_id"
   /** column name */
-  TransactionHash = "transaction_hash",
+  | "transaction_hash"
   /** column name */
-  TripleId = "triple_id",
+  | "triple_id"
   /** column name */
-  Type = "type"
-}
+  | "type"
 
 /** aggregate stddev on columns */
 export type Events_Stddev_Fields = {
@@ -3172,22 +3167,21 @@ export type Fee_Transfers_Order_By = {
 }
 
 /** select columns of table "fee_transfer" */
-export enum Fee_Transfers_Select_Column {
+export type Fee_Transfers_Select_Column =
   /** column name */
-  Amount = "amount",
+  | "amount"
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  ReceiverId = "receiver_id",
+  | "receiver_id"
   /** column name */
-  SenderId = "sender_id",
+  | "sender_id"
   /** column name */
-  TransactionHash = "transaction_hash"
-}
+  | "transaction_hash"
 
 /** aggregate stddev on columns */
 export type Fee_Transfers_Stddev_Fields = {
@@ -3409,12 +3403,11 @@ export type Json_Objects_Order_By = {
 }
 
 /** select columns of table "json_object" */
-export enum Json_Objects_Select_Column {
+export type Json_Objects_Select_Column =
   /** column name */
-  Data = "data",
+  | "data"
   /** column name */
-  Id = "id"
-}
+  | "id"
 
 /** aggregate stddev on columns */
 export type Json_Objects_Stddev_Fields = {
@@ -3540,20 +3533,19 @@ export type Numeric_Comparison_Exp = {
 }
 
 /** column ordering options */
-export enum Order_By {
+export type Order_By =
   /** in ascending order, nulls last */
-  Asc = "asc",
+  | "asc"
   /** in ascending order, nulls first */
-  AscNullsFirst = "asc_nulls_first",
+  | "asc_nulls_first"
   /** in ascending order, nulls last */
-  AscNullsLast = "asc_nulls_last",
+  | "asc_nulls_last"
   /** in descending order, nulls first */
-  Desc = "desc",
+  | "desc"
   /** in descending order, nulls first */
-  DescNullsFirst = "desc_nulls_first",
+  | "desc_nulls_first"
   /** in descending order, nulls last */
-  DescNullsLast = "desc_nulls_last"
-}
+  | "desc_nulls_last"
 
 /** columns and relationships of "organization" */
 export type Organizations = {
@@ -3651,20 +3643,19 @@ export type Organizations_Order_By = {
 }
 
 /** select columns of table "organization" */
-export enum Organizations_Select_Column {
+export type Organizations_Select_Column =
   /** column name */
-  Description = "description",
+  | "description"
   /** column name */
-  Email = "email",
+  | "email"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Image = "image",
+  | "image"
   /** column name */
-  Name = "name",
+  | "name"
   /** column name */
-  Url = "url"
-}
+  | "url"
 
 /** aggregate stddev on columns */
 export type Organizations_Stddev_Fields = {
@@ -3828,22 +3819,21 @@ export type Persons_Order_By = {
 }
 
 /** select columns of table "person" */
-export enum Persons_Select_Column {
+export type Persons_Select_Column =
   /** column name */
-  Description = "description",
+  | "description"
   /** column name */
-  Email = "email",
+  | "email"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Identifier = "identifier",
+  | "identifier"
   /** column name */
-  Image = "image",
+  | "image"
   /** column name */
-  Name = "name",
+  | "name"
   /** column name */
-  Url = "url"
-}
+  | "url"
 
 /** aggregate stddev on columns */
 export type Persons_Stddev_Fields = {
@@ -4058,18 +4048,17 @@ export type Positions_Order_By = {
 }
 
 /** select columns of table "position" */
-export enum Positions_Select_Column {
+export type Positions_Select_Column =
   /** column name */
-  AccountId = "account_id",
+  | "account_id"
   /** column name */
-  CurveId = "curve_id",
+  | "curve_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Shares = "shares",
+  | "shares"
   /** column name */
-  TermId = "term_id"
-}
+  | "term_id"
 
 /** aggregate stddev on columns */
 export type Positions_Stddev_Fields = {
@@ -4343,18 +4332,17 @@ export type Predicate_Objects_Order_By = {
 }
 
 /** select columns of table "predicate_object" */
-export enum Predicate_Objects_Select_Column {
+export type Predicate_Objects_Select_Column =
   /** column name */
-  ClaimCount = "claim_count",
+  | "claim_count"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  ObjectId = "object_id",
+  | "object_id"
   /** column name */
-  PredicateId = "predicate_id",
+  | "predicate_id"
   /** column name */
-  TripleCount = "triple_count"
-}
+  | "triple_count"
 
 /** aggregate stddev on columns */
 export type Predicate_Objects_Stddev_Fields = {
@@ -5456,32 +5444,31 @@ export type Redemptions_Order_By = {
 }
 
 /** select columns of table "redemption" */
-export enum Redemptions_Select_Column {
+export type Redemptions_Select_Column =
   /** column name */
-  AssetsForReceiver = "assets_for_receiver",
+  | "assets_for_receiver"
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  CurveId = "curve_id",
+  | "curve_id"
   /** column name */
-  ExitFee = "exit_fee",
+  | "exit_fee"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  ReceiverId = "receiver_id",
+  | "receiver_id"
   /** column name */
-  SenderId = "sender_id",
+  | "sender_id"
   /** column name */
-  SenderTotalSharesInVault = "sender_total_shares_in_vault",
+  | "sender_total_shares_in_vault"
   /** column name */
-  SharesRedeemedBySender = "shares_redeemed_by_sender",
+  | "shares_redeemed_by_sender"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TransactionHash = "transaction_hash"
-}
+  | "transaction_hash"
 
 /** aggregate stddev on columns */
 export type Redemptions_Stddev_Fields = {
@@ -5875,28 +5862,27 @@ export type Share_Price_Changes_Order_By = {
 }
 
 /** select columns of table "share_price_change" */
-export enum Share_Price_Changes_Select_Column {
+export type Share_Price_Changes_Select_Column =
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  CurveId = "curve_id",
+  | "curve_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  SharePrice = "share_price",
+  | "share_price"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TotalAssets = "total_assets",
+  | "total_assets"
   /** column name */
-  TotalShares = "total_shares",
+  | "total_shares"
   /** column name */
-  TransactionHash = "transaction_hash",
+  | "transaction_hash"
   /** column name */
-  UpdatedAt = "updated_at"
-}
+  | "updated_at"
 
 /** aggregate stddev on columns */
 export type Share_Price_Changes_Stddev_Fields = {
@@ -6298,28 +6284,27 @@ export type Signals_Order_By = {
 }
 
 /** select columns of table "signal" */
-export enum Signals_Select_Column {
+export type Signals_Select_Column =
   /** column name */
-  AccountId = "account_id",
+  | "account_id"
   /** column name */
-  AtomId = "atom_id",
+  | "atom_id"
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  Delta = "delta",
+  | "delta"
   /** column name */
-  DepositId = "deposit_id",
+  | "deposit_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  RedemptionId = "redemption_id",
+  | "redemption_id"
   /** column name */
-  TransactionHash = "transaction_hash",
+  | "transaction_hash"
   /** column name */
-  TripleId = "triple_id"
-}
+  | "triple_id"
 
 /** aggregate stddev on columns */
 export type Signals_Stddev_Fields = {
@@ -6585,24 +6570,23 @@ export type Stats_Order_By = {
 }
 
 /** select columns of table "stats" */
-export enum Stats_Select_Column {
+export type Stats_Select_Column =
   /** column name */
-  ContractBalance = "contract_balance",
+  | "contract_balance"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  TotalAccounts = "total_accounts",
+  | "total_accounts"
   /** column name */
-  TotalAtoms = "total_atoms",
+  | "total_atoms"
   /** column name */
-  TotalFees = "total_fees",
+  | "total_fees"
   /** column name */
-  TotalPositions = "total_positions",
+  | "total_positions"
   /** column name */
-  TotalSignals = "total_signals",
+  | "total_signals"
   /** column name */
-  TotalTriples = "total_triples"
-}
+  | "total_triples"
 
 /** aggregate stddev on columns */
 export type Stats_Stddev_Fields = {
@@ -7947,20 +7931,19 @@ export type Terms_Order_By = {
 }
 
 /** select columns of table "term" */
-export enum Terms_Select_Column {
+export type Terms_Select_Column =
   /** column name */
-  AtomId = "atom_id",
+  | "atom_id"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  TotalAssets = "total_assets",
+  | "total_assets"
   /** column name */
-  TotalMarketCap = "total_market_cap",
+  | "total_market_cap"
   /** column name */
-  TripleId = "triple_id",
+  | "triple_id"
   /** column name */
-  Type = "type"
-}
+  | "type"
 
 /** aggregate stddev on columns */
 export type Terms_Stddev_Fields = {
@@ -8126,12 +8109,11 @@ export type Text_Objects_Order_By = {
 }
 
 /** select columns of table "text_object" */
-export enum Text_Objects_Select_Column {
+export type Text_Objects_Select_Column =
   /** column name */
-  Data = "data",
+  | "data"
   /** column name */
-  Id = "id"
-}
+  | "id"
 
 /** aggregate stddev on columns */
 export type Text_Objects_Stddev_Fields = {
@@ -8281,18 +8263,17 @@ export type Things_Order_By = {
 }
 
 /** select columns of table "thing" */
-export enum Things_Select_Column {
+export type Things_Select_Column =
   /** column name */
-  Description = "description",
+  | "description"
   /** column name */
-  Id = "id",
+  | "id"
   /** column name */
-  Image = "image",
+  | "image"
   /** column name */
-  Name = "name",
+  | "name"
   /** column name */
-  Url = "url"
-}
+  | "url"
 
 /** aggregate stddev on columns */
 export type Things_Stddev_Fields = {
@@ -8616,26 +8597,25 @@ export type Triples_Order_By = {
 }
 
 /** select columns of table "triple" */
-export enum Triples_Select_Column {
+export type Triples_Select_Column =
   /** column name */
-  BlockNumber = "block_number",
+  | "block_number"
   /** column name */
-  BlockTimestamp = "block_timestamp",
+  | "block_timestamp"
   /** column name */
-  CounterTermId = "counter_term_id",
+  | "counter_term_id"
   /** column name */
-  CreatorId = "creator_id",
+  | "creator_id"
   /** column name */
-  ObjectId = "object_id",
+  | "object_id"
   /** column name */
-  PredicateId = "predicate_id",
+  | "predicate_id"
   /** column name */
-  SubjectId = "subject_id",
+  | "subject_id"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TransactionHash = "transaction_hash"
-}
+  | "transaction_hash"
 
 /** aggregate stddev on columns */
 export type Triples_Stddev_Fields = {
@@ -9110,22 +9090,21 @@ export type Vaults_Order_By = {
 }
 
 /** select columns of table "vault" */
-export enum Vaults_Select_Column {
+export type Vaults_Select_Column =
   /** column name */
-  CurrentSharePrice = "current_share_price",
+  | "current_share_price"
   /** column name */
-  CurveId = "curve_id",
+  | "curve_id"
   /** column name */
-  MarketCap = "market_cap",
+  | "market_cap"
   /** column name */
-  PositionCount = "position_count",
+  | "position_count"
   /** column name */
-  TermId = "term_id",
+  | "term_id"
   /** column name */
-  TotalAssets = "total_assets",
+  | "total_assets"
   /** column name */
-  TotalShares = "total_shares"
-}
+  | "total_shares"
 
 /** aggregate stddev on columns */
 export type Vaults_Stddev_Fields = {
@@ -17251,54 +17230,6 @@ export type GetTaggedObjectsQuery = {
   }>
 }
 
-export type GetTriplesByCreatorQueryVariables = Exact<{
-  address?: InputMaybe<Scalars["String"]["input"]>
-}>
-
-export type GetTriplesByCreatorQuery = {
-  __typename?: "query_root"
-  triples: Array<{
-    __typename?: "triples"
-    term_id: any
-    creator_id: string
-    subject: {
-      __typename?: "atoms"
-      term_id: any
-      label?: string | null
-      image?: string | null
-      type: any
-    }
-    predicate: {
-      __typename?: "atoms"
-      term_id: any
-      label?: string | null
-      image?: string | null
-      type: any
-    }
-    object: {
-      __typename?: "atoms"
-      term_id: any
-      label?: string | null
-      image?: string | null
-      type: any
-    }
-    positions_aggregate: {
-      __typename?: "positions_aggregate"
-      aggregate?: {
-        __typename?: "positions_aggregate_fields"
-        count: number
-      } | null
-    }
-    counter_positions_aggregate: {
-      __typename?: "positions_aggregate"
-      aggregate?: {
-        __typename?: "positions_aggregate_fields"
-        count: number
-      } | null
-    }
-  }>
-}
-
 export type GetTriplesQueryVariables = Exact<{
   limit?: InputMaybe<Scalars["Int"]["input"]>
   offset?: InputMaybe<Scalars["Int"]["input"]>
@@ -19491,7 +19422,7793 @@ export type EventsSubscription = {
   }>
 }
 
-export const AccountClaimsAggregateFragmentDoc = {
+export const AccountClaimsAggregateFragmentDoc = `
+    fragment AccountClaimsAggregate on accounts {
+  claims_aggregate(order_by: {position: {shares: desc}}) {
+    aggregate {
+      count
+    }
+    nodes {
+      id
+      position {
+        shares
+      }
+    }
+  }
+}
+    `
+export const AccountClaimsFragmentDoc = `
+    fragment AccountClaims on accounts {
+  claims(
+    order_by: {position: {shares: desc}}
+    limit: $claimsLimit
+    offset: $claimsOffset
+    where: $claimsWhere
+  ) {
+    id
+    position {
+      shares
+    }
+  }
+}
+    `
+export const AccountPositionsAggregateFragmentDoc = `
+    fragment AccountPositionsAggregate on accounts {
+  positions_aggregate(order_by: {shares: desc}) {
+    aggregate {
+      count
+    }
+    nodes {
+      id
+      shares
+      vault {
+        term_id
+        total_shares
+        current_share_price
+        term {
+          atom {
+            term_id
+            label
+          }
+          triple {
+            term_id
+          }
+        }
+      }
+    }
+  }
+}
+    `
+export const AccountPositionsFragmentDoc = `
+    fragment AccountPositions on accounts {
+  positions(
+    order_by: {shares: desc}
+    limit: $positionsLimit
+    offset: $positionsOffset
+    where: $positionsWhere
+  ) {
+    id
+    shares
+    vault {
+      term_id
+      total_shares
+      current_share_price
+      term {
+        atom {
+          term_id
+          label
+        }
+        triple {
+          term_id
+        }
+      }
+    }
+  }
+}
+    `
+export const AccountAtomsFragmentDoc = `
+    fragment AccountAtoms on accounts {
+  atoms(
+    where: $atomsWhere
+    order_by: $atomsOrderBy
+    limit: $atomsLimit
+    offset: $atomsOffset
+  ) {
+    term_id
+    label
+    data
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        positions_aggregate(where: {account_id: {_eq: $address}}) {
+          nodes {
+            account {
+              id
+            }
+            shares
+          }
+        }
+      }
+    }
+  }
+}
+    `
+export const AccountAtomsAggregateFragmentDoc = `
+    fragment AccountAtomsAggregate on accounts {
+  atoms_aggregate(
+    where: $atomsWhere
+    order_by: $atomsOrderBy
+    limit: $atomsLimit
+    offset: $atomsOffset
+  ) {
+    aggregate {
+      count
+      sum {
+        term_id
+      }
+    }
+    nodes {
+      term_id
+      label
+      data
+      term {
+        vaults(where: {curve_id: {_eq: "1"}}) {
+          total_shares
+          positions_aggregate(where: {account_id: {_eq: $address}}) {
+            nodes {
+              account {
+                id
+              }
+              shares
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    `
+export const AccountTriplesFragmentDoc = `
+    fragment AccountTriples on accounts {
+  triples_aggregate(
+    where: $triplesWhere
+    order_by: $triplesOrderBy
+    limit: $triplesLimit
+    offset: $triplesOffset
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      term_id
+      subject {
+        term_id
+        label
+      }
+      predicate {
+        term_id
+        label
+      }
+      object {
+        term_id
+        label
+      }
+    }
+  }
+}
+    `
+export const AccountTriplesAggregateFragmentDoc = `
+    fragment AccountTriplesAggregate on accounts {
+  triples_aggregate(
+    where: $triplesWhere
+    order_by: $triplesOrderBy
+    limit: $triplesLimit
+    offset: $triplesOffset
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      term_id
+      subject {
+        term_id
+        label
+      }
+      predicate {
+        term_id
+        label
+      }
+      object {
+        term_id
+        label
+      }
+    }
+  }
+}
+    `
+export const AtomTxnFragmentDoc = `
+    fragment AtomTxn on atoms {
+  block_number
+  block_timestamp
+  transaction_hash
+  creator_id
+}
+    `
+export const AtomVaultDetailsFragmentDoc = `
+    fragment AtomVaultDetails on atoms {
+  term_id
+  wallet_id
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      position_count
+      total_shares
+      current_share_price
+      positions_aggregate {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      positions {
+        id
+        account {
+          label
+          id
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+export const AccountMetadataFragmentDoc = `
+    fragment AccountMetadata on accounts {
+  label
+  image
+  id
+  atom_id
+  type
+}
+    `
+export const AtomTripleFragmentDoc = `
+    fragment AtomTriple on atoms {
+  as_subject_triples {
+    term_id
+    object {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+    predicate {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+  }
+  as_predicate_triples {
+    term_id
+    subject {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+    object {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+  }
+  as_object_triples {
+    term_id
+    subject {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+    predicate {
+      data
+      term_id
+      image
+      label
+      emoji
+      type
+      creator {
+        ...AccountMetadata
+      }
+    }
+  }
+}
+    `
+export const AtomVaultDetailsWithPositionsFragmentDoc = `
+    fragment AtomVaultDetailsWithPositions on atoms {
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      total_shares
+      current_share_price
+      positions_aggregate(where: {account_id: {_in: $addresses}}) {
+        aggregate {
+          sum {
+            shares
+          }
+        }
+        nodes {
+          account {
+            id
+          }
+          shares
+        }
+      }
+    }
+  }
+}
+    `
+export const DepositEventFragmentFragmentDoc = `
+    fragment DepositEventFragment on events {
+  deposit {
+    term_id
+    curve_id
+    sender_assets_after_total_fees
+    shares_for_receiver
+    receiver {
+      id
+    }
+    sender {
+      id
+    }
+  }
+}
+    `
+export const RedemptionEventFragmentFragmentDoc = `
+    fragment RedemptionEventFragment on events {
+  redemption {
+    term_id
+    curve_id
+    receiver_id
+    shares_redeemed_by_sender
+    assets_for_receiver
+  }
+}
+    `
+export const AtomValueFragmentDoc = `
+    fragment AtomValue on atoms {
+  value {
+    person {
+      name
+      image
+      description
+      url
+    }
+    thing {
+      name
+      image
+      description
+      url
+    }
+    organization {
+      name
+      image
+      description
+      url
+    }
+  }
+}
+    `
+export const AtomMetadataFragmentDoc = `
+    fragment AtomMetadata on atoms {
+  term_id
+  data
+  image
+  label
+  emoji
+  type
+  wallet_id
+  creator {
+    id
+    label
+    image
+  }
+  ...AtomValue
+}
+    `
+export const PositionAggregateFieldsFragmentDoc = `
+    fragment PositionAggregateFields on positions_aggregate {
+  aggregate {
+    count
+    sum {
+      shares
+    }
+  }
+}
+    `
+export const PositionFieldsFragmentDoc = `
+    fragment PositionFields on positions {
+  account {
+    id
+    label
+  }
+  shares
+  vault {
+    term_id
+    total_shares
+    current_share_price
+  }
+}
+    `
+export const TripleMetadataFragmentDoc = `
+    fragment TripleMetadata on triples {
+  term_id
+  subject_id
+  predicate_id
+  object_id
+  subject {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    ...AtomValue
+    creator {
+      ...AccountMetadata
+    }
+  }
+  predicate {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    ...AtomValue
+    creator {
+      ...AccountMetadata
+    }
+  }
+  object {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    ...AtomValue
+    creator {
+      ...AccountMetadata
+    }
+  }
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      total_shares
+      current_share_price
+      allPositions: positions_aggregate {
+        ...PositionAggregateFields
+      }
+      positions {
+        ...PositionFields
+      }
+    }
+  }
+  counter_term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      total_shares
+      current_share_price
+      allPositions: positions_aggregate {
+        ...PositionAggregateFields
+      }
+      positions {
+        ...PositionFields
+      }
+    }
+  }
+}
+    `
+export const EventDetailsFragmentDoc = `
+    fragment EventDetails on events {
+  block_number
+  block_timestamp
+  type
+  transaction_hash
+  atom_id
+  triple_id
+  deposit_id
+  redemption_id
+  ...DepositEventFragment
+  ...RedemptionEventFragment
+  atom {
+    ...AtomMetadata
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        position_count
+        positions {
+          account_id
+          shares
+          account {
+            id
+            label
+            image
+          }
+        }
+      }
+    }
+  }
+  triple {
+    ...TripleMetadata
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        position_count
+        positions {
+          account_id
+          shares
+          account {
+            id
+            label
+            image
+          }
+        }
+      }
+    }
+    counter_term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        position_count
+        positions {
+          account_id
+          shares
+          account {
+            id
+            label
+            image
+          }
+        }
+      }
+    }
+  }
+}
+    `
+export const TripleMetadataSubscriptionFragmentDoc = `
+    fragment TripleMetadataSubscription on triples {
+  term_id
+  creator {
+    image
+    label
+    id
+  }
+  creator_id
+  subject_id
+  predicate_id
+  object_id
+  subject {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    creator {
+      ...AccountMetadata
+    }
+  }
+  predicate {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    creator {
+      ...AccountMetadata
+    }
+  }
+  object {
+    data
+    term_id
+    image
+    label
+    emoji
+    type
+    creator {
+      ...AccountMetadata
+    }
+  }
+}
+    `
+export const VaultBasicDetailsFragmentDoc = `
+    fragment VaultBasicDetails on vaults {
+  term_id
+  curve_id
+  term {
+    atom {
+      term_id
+      label
+    }
+    triple {
+      term_id
+      subject {
+        term_id
+        label
+      }
+      predicate {
+        term_id
+        label
+      }
+      object {
+        term_id
+        label
+      }
+    }
+  }
+  current_share_price
+  total_shares
+}
+    `
+export const VaultFilteredPositionsFragmentDoc = `
+    fragment VaultFilteredPositions on vaults {
+  positions(where: {account_id: {_in: $addresses}}) {
+    ...PositionFields
+  }
+}
+    `
+export const VaultDetailsWithFilteredPositionsFragmentDoc = `
+    fragment VaultDetailsWithFilteredPositions on vaults {
+  ...VaultBasicDetails
+  ...VaultFilteredPositions
+}
+    `
+export const TripleVaultCouterVaultDetailsWithPositionsFragmentDoc = `
+    fragment TripleVaultCouterVaultDetailsWithPositions on triples {
+  term_id
+  counter_term_id
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      ...VaultDetailsWithFilteredPositions
+    }
+  }
+  counter_term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      ...VaultDetailsWithFilteredPositions
+    }
+  }
+}
+    `
+export const EventDetailsSubscriptionFragmentDoc = `
+    fragment EventDetailsSubscription on events {
+  block_number
+  block_timestamp
+  type
+  transaction_hash
+  atom_id
+  triple_id
+  deposit_id
+  redemption_id
+  ...DepositEventFragment
+  ...RedemptionEventFragment
+  atom {
+    ...AtomMetadata
+    term_id
+    term {
+      id
+      total_market_cap
+      vaults {
+        position_count
+      }
+      positions {
+        account_id
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
+    }
+  }
+  triple {
+    ...TripleMetadataSubscription
+    ...TripleVaultCouterVaultDetailsWithPositions
+    term_id
+    counter_term_id
+    positions_aggregate {
+      aggregate {
+        count
+      }
+    }
+  }
+}
+    `
+export const FollowMetadataFragmentDoc = `
+    fragment FollowMetadata on triples {
+  term_id
+  subject {
+    term_id
+    label
+  }
+  predicate {
+    term_id
+    label
+  }
+  object {
+    term_id
+    label
+  }
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      term_id
+      total_shares
+      current_share_price
+      positions_aggregate(where: $positionsWhere) {
+        aggregate {
+          count
+          sum {
+            shares
+          }
+        }
+      }
+      positions(
+        limit: $positionsLimit
+        offset: $positionsOffset
+        order_by: $positionsOrderBy
+        where: $positionsWhere
+      ) {
+        account {
+          id
+          label
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+export const FollowAggregateFragmentDoc = `
+    fragment FollowAggregate on triples_aggregate {
+  aggregate {
+    count
+  }
+}
+    `
+export const StatDetailsFragmentDoc = `
+    fragment StatDetails on stats {
+  contract_balance
+  total_accounts
+  total_fees
+  total_atoms
+  total_triples
+  total_positions
+  total_signals
+}
+    `
+export const TripleTxnFragmentDoc = `
+    fragment TripleTxn on triples {
+  block_number
+  block_timestamp
+  transaction_hash
+  creator_id
+}
+    `
+export const PositionDetailsFragmentDoc = `
+    fragment PositionDetails on positions {
+  id
+  account {
+    id
+    label
+    image
+  }
+  vault {
+    term_id
+    term {
+      atom {
+        term_id
+        label
+        image
+      }
+      triple {
+        term_id
+        term {
+          vaults(where: {curve_id: {_eq: "1"}}) {
+            term_id
+            position_count
+            positions_aggregate {
+              aggregate {
+                sum {
+                  shares
+                }
+              }
+            }
+          }
+        }
+        counter_term {
+          vaults(where: {curve_id: {_eq: "1"}}) {
+            term_id
+            position_count
+            positions_aggregate {
+              aggregate {
+                sum {
+                  shares
+                }
+              }
+            }
+          }
+        }
+        subject {
+          data
+          term_id
+          label
+          image
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+        predicate {
+          data
+          term_id
+          label
+          image
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+        object {
+          data
+          term_id
+          label
+          image
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+      }
+    }
+  }
+  shares
+  term_id
+  curve_id
+}
+    `
+export const TripleVaultDetailsFragmentDoc = `
+    fragment TripleVaultDetails on triples {
+  term_id
+  counter_term_id
+  term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      positions {
+        ...PositionDetails
+      }
+    }
+  }
+  counter_term {
+    vaults(where: {curve_id: {_eq: "1"}}) {
+      positions {
+        ...PositionDetails
+      }
+    }
+  }
+}
+    `
+export const VaultUnfilteredPositionsFragmentDoc = `
+    fragment VaultUnfilteredPositions on vaults {
+  positions {
+    ...PositionFields
+  }
+}
+    `
+export const VaultDetailsFragmentDoc = `
+    fragment VaultDetails on vaults {
+  ...VaultBasicDetails
+}
+    `
+export const VaultPositionsAggregateFragmentDoc = `
+    fragment VaultPositionsAggregate on vaults {
+  positions_aggregate {
+    ...PositionAggregateFields
+  }
+}
+    `
+export const VaultFieldsForTripleFragmentDoc = `
+    fragment VaultFieldsForTriple on vaults {
+  total_shares
+  current_share_price
+  ...VaultPositionsAggregate
+  ...VaultFilteredPositions
+}
+    `
+export const AtomMetadataMaybedeletethisFragmentDoc = `
+    fragment AtomMetadataMAYBEDELETETHIS on atoms {
+  term_id
+  data
+  image
+  label
+  emoji
+  type
+  wallet_id
+  creator {
+    id
+    label
+    image
+  }
+  ...AtomValue
+}
+    `
+export const PinThingDocument = `
+    mutation pinThing($name: String!, $description: String, $image: String, $url: String) {
+  pinThing(
+    thing: {description: $description, image: $image, name: $name, url: $url}
+  ) {
+    uri
+  }
+}
+    `
+
+export const usePinThingMutation = <TError = unknown, TContext = unknown>(
+  options?: UseMutationOptions<
+    PinThingMutation,
+    TError,
+    PinThingMutationVariables,
+    TContext
+  >
+) => {
+  return useMutation<
+    PinThingMutation,
+    TError,
+    PinThingMutationVariables,
+    TContext
+  >({
+    mutationKey: ["pinThing"],
+    mutationFn: (variables?: PinThingMutationVariables) =>
+      fetcher<PinThingMutation, PinThingMutationVariables>(
+        PinThingDocument,
+        variables
+      )(),
+    ...options
+  })
+}
+
+usePinThingMutation.getKey = () => ["pinThing"]
+
+usePinThingMutation.fetcher = (
+  variables: PinThingMutationVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<PinThingMutation, PinThingMutationVariables>(
+    PinThingDocument,
+    variables,
+    options
+  )
+
+export const GetAccountsDocument = `
+    query GetAccounts($limit: Int, $offset: Int, $orderBy: [accounts_order_by!], $where: accounts_bool_exp, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp) {
+  accounts(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...AccountMetadata
+    ...AccountClaims
+    ...AccountPositions
+    atom {
+      term_id
+      wallet_id
+      term {
+        vaults(where: {curve_id: {_eq: "1"}}) {
+          position_count
+          total_shares
+          positions_aggregate {
+            aggregate {
+              count
+              sum {
+                shares
+              }
+            }
+          }
+          positions {
+            id
+            account {
+              label
+              id
+            }
+            shares
+          }
+        }
+      }
+    }
+  }
+}
+    ${AccountMetadataFragmentDoc}
+${AccountClaimsFragmentDoc}
+${AccountPositionsFragmentDoc}`
+
+export const useGetAccountsQuery = <TData = GetAccountsQuery, TError = unknown>(
+  variables?: GetAccountsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAccountsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetAccounts"] : ["GetAccounts", variables],
+    queryFn: fetcher<GetAccountsQuery, GetAccountsQueryVariables>(
+      GetAccountsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAccountsQuery.document = GetAccountsDocument
+
+useGetAccountsQuery.getKey = (variables?: GetAccountsQueryVariables) =>
+  variables === undefined ? ["GetAccounts"] : ["GetAccounts", variables]
+
+export const useInfiniteGetAccountsQuery = <
+  TData = InfiniteData<GetAccountsQuery>,
+  TError = unknown
+>(
+  variables: GetAccountsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAccounts.infinite"]
+            : ["GetAccounts.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAccountsQuery, GetAccountsQueryVariables>(
+            GetAccountsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountsQuery.getKey = (variables?: GetAccountsQueryVariables) =>
+  variables === undefined
+    ? ["GetAccounts.infinite"]
+    : ["GetAccounts.infinite", variables]
+
+useGetAccountsQuery.fetcher = (
+  variables?: GetAccountsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAccountsQuery, GetAccountsQueryVariables>(
+    GetAccountsDocument,
+    variables,
+    options
+  )
+
+export const GetAccountsWithAggregatesDocument = `
+    query GetAccountsWithAggregates($limit: Int, $offset: Int, $orderBy: [accounts_order_by!], $where: accounts_bool_exp, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp, $atomsWhere: atoms_bool_exp, $atomsOrderBy: [atoms_order_by!], $atomsLimit: Int, $atomsOffset: Int) {
+  accounts_aggregate(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+    where: $where
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      ...AccountMetadata
+      ...AccountClaims
+      ...AccountPositions
+    }
+  }
+}
+    ${AccountMetadataFragmentDoc}
+${AccountClaimsFragmentDoc}
+${AccountPositionsFragmentDoc}`
+
+export const useGetAccountsWithAggregatesQuery = <
+  TData = GetAccountsWithAggregatesQuery,
+  TError = unknown
+>(
+  variables?: GetAccountsWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAccountsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountsWithAggregatesQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAccountsWithAggregates"]
+        : ["GetAccountsWithAggregates", variables],
+    queryFn: fetcher<
+      GetAccountsWithAggregatesQuery,
+      GetAccountsWithAggregatesQueryVariables
+    >(GetAccountsWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetAccountsWithAggregatesQuery.document = GetAccountsWithAggregatesDocument
+
+useGetAccountsWithAggregatesQuery.getKey = (
+  variables?: GetAccountsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAccountsWithAggregates"]
+    : ["GetAccountsWithAggregates", variables]
+
+export const useInfiniteGetAccountsWithAggregatesQuery = <
+  TData = InfiniteData<GetAccountsWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetAccountsWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountsWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAccountsWithAggregates.infinite"]
+            : ["GetAccountsWithAggregates.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAccountsWithAggregatesQuery,
+            GetAccountsWithAggregatesQueryVariables
+          >(GetAccountsWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountsWithAggregatesQuery.getKey = (
+  variables?: GetAccountsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAccountsWithAggregates.infinite"]
+    : ["GetAccountsWithAggregates.infinite", variables]
+
+useGetAccountsWithAggregatesQuery.fetcher = (
+  variables?: GetAccountsWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetAccountsWithAggregatesQuery,
+    GetAccountsWithAggregatesQueryVariables
+  >(GetAccountsWithAggregatesDocument, variables, options)
+
+export const GetAccountsCountDocument = `
+    query GetAccountsCount($where: accounts_bool_exp) {
+  accounts_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetAccountsCountQuery = <
+  TData = GetAccountsCountQuery,
+  TError = unknown
+>(
+  variables?: GetAccountsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAccountsCountQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountsCountQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAccountsCount"]
+        : ["GetAccountsCount", variables],
+    queryFn: fetcher<GetAccountsCountQuery, GetAccountsCountQueryVariables>(
+      GetAccountsCountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAccountsCountQuery.document = GetAccountsCountDocument
+
+useGetAccountsCountQuery.getKey = (
+  variables?: GetAccountsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAccountsCount"]
+    : ["GetAccountsCount", variables]
+
+export const useInfiniteGetAccountsCountQuery = <
+  TData = InfiniteData<GetAccountsCountQuery>,
+  TError = unknown
+>(
+  variables: GetAccountsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAccountsCount.infinite"]
+            : ["GetAccountsCount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAccountsCountQuery, GetAccountsCountQueryVariables>(
+            GetAccountsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountsCountQuery.getKey = (
+  variables?: GetAccountsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAccountsCount.infinite"]
+    : ["GetAccountsCount.infinite", variables]
+
+useGetAccountsCountQuery.fetcher = (
+  variables?: GetAccountsCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAccountsCountQuery, GetAccountsCountQueryVariables>(
+    GetAccountsCountDocument,
+    variables,
+    options
+  )
+
+export const GetAccountDocument = `
+    query GetAccount($address: String!, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp, $atomsWhere: atoms_bool_exp, $atomsOrderBy: [atoms_order_by!], $atomsLimit: Int, $atomsOffset: Int, $triplesWhere: triples_bool_exp, $triplesOrderBy: [triples_order_by!], $triplesLimit: Int, $triplesOffset: Int) {
+  account(id: $address) {
+    ...AccountMetadata
+    atom {
+      ...AtomMetadata
+      ...AtomVaultDetails
+    }
+    ...AccountClaims
+    ...AccountPositions
+    ...AccountAtoms
+    ...AccountTriples
+  }
+  chainlink_prices(limit: 1, order_by: {id: desc}) {
+    usd
+  }
+}
+    ${AccountMetadataFragmentDoc}
+${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
+${AccountClaimsFragmentDoc}
+${AccountPositionsFragmentDoc}
+${AccountAtomsFragmentDoc}
+${AccountTriplesFragmentDoc}`
+
+export const useGetAccountQuery = <TData = GetAccountQuery, TError = unknown>(
+  variables: GetAccountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountQuery, TError, TData>,
+    "queryKey"
+  > & { queryKey?: UseQueryOptions<GetAccountQuery, TError, TData>["queryKey"] }
+) => {
+  return useQuery<GetAccountQuery, TError, TData>({
+    queryKey: ["GetAccount", variables],
+    queryFn: fetcher<GetAccountQuery, GetAccountQueryVariables>(
+      GetAccountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAccountQuery.document = GetAccountDocument
+
+useGetAccountQuery.getKey = (variables: GetAccountQueryVariables) => [
+  "GetAccount",
+  variables
+]
+
+export const useInfiniteGetAccountQuery = <
+  TData = InfiniteData<GetAccountQuery>,
+  TError = unknown
+>(
+  variables: GetAccountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAccount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAccountQuery, GetAccountQueryVariables>(
+            GetAccountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountQuery.getKey = (variables: GetAccountQueryVariables) => [
+  "GetAccount.infinite",
+  variables
+]
+
+useGetAccountQuery.fetcher = (
+  variables: GetAccountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAccountQuery, GetAccountQueryVariables>(
+    GetAccountDocument,
+    variables,
+    options
+  )
+
+export const GetAccountWithPaginatedRelationsDocument = `
+    query GetAccountWithPaginatedRelations($address: String!, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp, $atomsLimit: Int, $atomsOffset: Int, $atomsWhere: atoms_bool_exp, $atomsOrderBy: [atoms_order_by!], $triplesLimit: Int, $triplesOffset: Int, $triplesWhere: triples_bool_exp, $triplesOrderBy: [triples_order_by!]) {
+  account(id: $address) {
+    ...AccountMetadata
+    ...AccountClaims
+    ...AccountPositions
+    ...AccountAtoms
+    ...AccountTriples
+  }
+}
+    ${AccountMetadataFragmentDoc}
+${AccountClaimsFragmentDoc}
+${AccountPositionsFragmentDoc}
+${AccountAtomsFragmentDoc}
+${AccountTriplesFragmentDoc}`
+
+export const useGetAccountWithPaginatedRelationsQuery = <
+  TData = GetAccountWithPaginatedRelationsQuery,
+  TError = unknown
+>(
+  variables: GetAccountWithPaginatedRelationsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountWithPaginatedRelationsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAccountWithPaginatedRelationsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountWithPaginatedRelationsQuery, TError, TData>({
+    queryKey: ["GetAccountWithPaginatedRelations", variables],
+    queryFn: fetcher<
+      GetAccountWithPaginatedRelationsQuery,
+      GetAccountWithPaginatedRelationsQueryVariables
+    >(GetAccountWithPaginatedRelationsDocument, variables),
+    ...options
+  })
+}
+
+useGetAccountWithPaginatedRelationsQuery.document =
+  GetAccountWithPaginatedRelationsDocument
+
+useGetAccountWithPaginatedRelationsQuery.getKey = (
+  variables: GetAccountWithPaginatedRelationsQueryVariables
+) => ["GetAccountWithPaginatedRelations", variables]
+
+export const useInfiniteGetAccountWithPaginatedRelationsQuery = <
+  TData = InfiniteData<GetAccountWithPaginatedRelationsQuery>,
+  TError = unknown
+>(
+  variables: GetAccountWithPaginatedRelationsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<
+      GetAccountWithPaginatedRelationsQuery,
+      TError,
+      TData
+    >,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountWithPaginatedRelationsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountWithPaginatedRelationsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetAccountWithPaginatedRelations.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAccountWithPaginatedRelationsQuery,
+            GetAccountWithPaginatedRelationsQueryVariables
+          >(GetAccountWithPaginatedRelationsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountWithPaginatedRelationsQuery.getKey = (
+  variables: GetAccountWithPaginatedRelationsQueryVariables
+) => ["GetAccountWithPaginatedRelations.infinite", variables]
+
+useGetAccountWithPaginatedRelationsQuery.fetcher = (
+  variables: GetAccountWithPaginatedRelationsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetAccountWithPaginatedRelationsQuery,
+    GetAccountWithPaginatedRelationsQueryVariables
+  >(GetAccountWithPaginatedRelationsDocument, variables, options)
+
+export const GetAccountWithAggregatesDocument = `
+    query GetAccountWithAggregates($address: String!, $claimsLimit: Int, $claimsOffset: Int, $claimsWhere: claims_bool_exp, $positionsLimit: Int, $positionsOffset: Int, $positionsWhere: positions_bool_exp, $atomsWhere: atoms_bool_exp, $atomsOrderBy: [atoms_order_by!], $atomsLimit: Int, $atomsOffset: Int, $triplesWhere: triples_bool_exp, $triplesOrderBy: [triples_order_by!], $triplesLimit: Int, $triplesOffset: Int) {
+  account(id: $address) {
+    ...AccountMetadata
+    ...AccountClaimsAggregate
+    ...AccountPositionsAggregate
+    ...AccountAtomsAggregate
+    ...AccountTriplesAggregate
+  }
+}
+    ${AccountMetadataFragmentDoc}
+${AccountClaimsAggregateFragmentDoc}
+${AccountPositionsAggregateFragmentDoc}
+${AccountAtomsAggregateFragmentDoc}
+${AccountTriplesAggregateFragmentDoc}`
+
+export const useGetAccountWithAggregatesQuery = <
+  TData = GetAccountWithAggregatesQuery,
+  TError = unknown
+>(
+  variables: GetAccountWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAccountWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountWithAggregatesQuery, TError, TData>({
+    queryKey: ["GetAccountWithAggregates", variables],
+    queryFn: fetcher<
+      GetAccountWithAggregatesQuery,
+      GetAccountWithAggregatesQueryVariables
+    >(GetAccountWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetAccountWithAggregatesQuery.document = GetAccountWithAggregatesDocument
+
+useGetAccountWithAggregatesQuery.getKey = (
+  variables: GetAccountWithAggregatesQueryVariables
+) => ["GetAccountWithAggregates", variables]
+
+export const useInfiniteGetAccountWithAggregatesQuery = <
+  TData = InfiniteData<GetAccountWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetAccountWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetAccountWithAggregates.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAccountWithAggregatesQuery,
+            GetAccountWithAggregatesQueryVariables
+          >(GetAccountWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountWithAggregatesQuery.getKey = (
+  variables: GetAccountWithAggregatesQueryVariables
+) => ["GetAccountWithAggregates.infinite", variables]
+
+useGetAccountWithAggregatesQuery.fetcher = (
+  variables: GetAccountWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetAccountWithAggregatesQuery,
+    GetAccountWithAggregatesQueryVariables
+  >(GetAccountWithAggregatesDocument, variables, options)
+
+export const GetAtomsDocument = `
+    query GetAtoms($limit: Int, $offset: Int, $orderBy: [atoms_order_by!], $where: atoms_bool_exp) {
+  total: atoms_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  atoms(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...AtomMetadata
+    ...AtomTxn
+    ...AtomVaultDetails
+    ...AtomTriple
+    creator {
+      ...AccountMetadata
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomTxnFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
+${AtomTripleFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetAtomsQuery = <TData = GetAtomsQuery, TError = unknown>(
+  variables?: GetAtomsQueryVariables,
+  options?: Omit<UseQueryOptions<GetAtomsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetAtomsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomsQuery, TError, TData>({
+    queryKey: variables === undefined ? ["GetAtoms"] : ["GetAtoms", variables],
+    queryFn: fetcher<GetAtomsQuery, GetAtomsQueryVariables>(
+      GetAtomsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomsQuery.document = GetAtomsDocument
+
+useGetAtomsQuery.getKey = (variables?: GetAtomsQueryVariables) =>
+  variables === undefined ? ["GetAtoms"] : ["GetAtoms", variables]
+
+export const useInfiniteGetAtomsQuery = <
+  TData = InfiniteData<GetAtomsQuery>,
+  TError = unknown
+>(
+  variables: GetAtomsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetAtomsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAtoms.infinite"]
+            : ["GetAtoms.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomsQuery, GetAtomsQueryVariables>(GetAtomsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomsQuery.getKey = (variables?: GetAtomsQueryVariables) =>
+  variables === undefined
+    ? ["GetAtoms.infinite"]
+    : ["GetAtoms.infinite", variables]
+
+useGetAtomsQuery.fetcher = (
+  variables?: GetAtomsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomsQuery, GetAtomsQueryVariables>(
+    GetAtomsDocument,
+    variables,
+    options
+  )
+
+export const GetAtomsWithPositionsDocument = `
+    query GetAtomsWithPositions($limit: Int, $offset: Int, $orderBy: [atoms_order_by!], $where: atoms_bool_exp, $address: String) {
+  total: atoms_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  atoms(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...AtomMetadata
+    ...AtomTxn
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        position_count
+        total_shares
+        current_share_price
+        total: positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          id
+          account {
+            label
+            id
+          }
+          shares
+        }
+      }
+    }
+    creator {
+      ...AccountMetadata
+    }
+    as_subject_triples_aggregate {
+      nodes {
+        predicate {
+          label
+          term_id
+        }
+        object {
+          label
+          term_id
+        }
+      }
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomTxnFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetAtomsWithPositionsQuery = <
+  TData = GetAtomsWithPositionsQuery,
+  TError = unknown
+>(
+  variables?: GetAtomsWithPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomsWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAtomsWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomsWithPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAtomsWithPositions"]
+        : ["GetAtomsWithPositions", variables],
+    queryFn: fetcher<
+      GetAtomsWithPositionsQuery,
+      GetAtomsWithPositionsQueryVariables
+    >(GetAtomsWithPositionsDocument, variables),
+    ...options
+  })
+}
+
+useGetAtomsWithPositionsQuery.document = GetAtomsWithPositionsDocument
+
+useGetAtomsWithPositionsQuery.getKey = (
+  variables?: GetAtomsWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomsWithPositions"]
+    : ["GetAtomsWithPositions", variables]
+
+export const useInfiniteGetAtomsWithPositionsQuery = <
+  TData = InfiniteData<GetAtomsWithPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetAtomsWithPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomsWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomsWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomsWithPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAtomsWithPositions.infinite"]
+            : ["GetAtomsWithPositions.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAtomsWithPositionsQuery,
+            GetAtomsWithPositionsQueryVariables
+          >(GetAtomsWithPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomsWithPositionsQuery.getKey = (
+  variables?: GetAtomsWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomsWithPositions.infinite"]
+    : ["GetAtomsWithPositions.infinite", variables]
+
+useGetAtomsWithPositionsQuery.fetcher = (
+  variables?: GetAtomsWithPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomsWithPositionsQuery, GetAtomsWithPositionsQueryVariables>(
+    GetAtomsWithPositionsDocument,
+    variables,
+    options
+  )
+
+export const GetAtomsWithAggregatesDocument = `
+    query GetAtomsWithAggregates($limit: Int, $offset: Int, $orderBy: [atoms_order_by!], $where: atoms_bool_exp) {
+  atoms_aggregate(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+    where: $where
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      ...AtomMetadata
+      ...AtomTxn
+      ...AtomVaultDetails
+      creator {
+        ...AccountMetadata
+      }
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomTxnFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetAtomsWithAggregatesQuery = <
+  TData = GetAtomsWithAggregatesQuery,
+  TError = unknown
+>(
+  variables?: GetAtomsWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAtomsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomsWithAggregatesQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAtomsWithAggregates"]
+        : ["GetAtomsWithAggregates", variables],
+    queryFn: fetcher<
+      GetAtomsWithAggregatesQuery,
+      GetAtomsWithAggregatesQueryVariables
+    >(GetAtomsWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetAtomsWithAggregatesQuery.document = GetAtomsWithAggregatesDocument
+
+useGetAtomsWithAggregatesQuery.getKey = (
+  variables?: GetAtomsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomsWithAggregates"]
+    : ["GetAtomsWithAggregates", variables]
+
+export const useInfiniteGetAtomsWithAggregatesQuery = <
+  TData = InfiniteData<GetAtomsWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetAtomsWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomsWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAtomsWithAggregates.infinite"]
+            : ["GetAtomsWithAggregates.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAtomsWithAggregatesQuery,
+            GetAtomsWithAggregatesQueryVariables
+          >(GetAtomsWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomsWithAggregatesQuery.getKey = (
+  variables?: GetAtomsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomsWithAggregates.infinite"]
+    : ["GetAtomsWithAggregates.infinite", variables]
+
+useGetAtomsWithAggregatesQuery.fetcher = (
+  variables?: GetAtomsWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomsWithAggregatesQuery, GetAtomsWithAggregatesQueryVariables>(
+    GetAtomsWithAggregatesDocument,
+    variables,
+    options
+  )
+
+export const GetAtomsCountDocument = `
+    query GetAtomsCount($where: atoms_bool_exp) {
+  atoms_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetAtomsCountQuery = <
+  TData = GetAtomsCountQuery,
+  TError = unknown
+>(
+  variables?: GetAtomsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAtomsCountQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomsCountQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAtomsCount"]
+        : ["GetAtomsCount", variables],
+    queryFn: fetcher<GetAtomsCountQuery, GetAtomsCountQueryVariables>(
+      GetAtomsCountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomsCountQuery.document = GetAtomsCountDocument
+
+useGetAtomsCountQuery.getKey = (variables?: GetAtomsCountQueryVariables) =>
+  variables === undefined ? ["GetAtomsCount"] : ["GetAtomsCount", variables]
+
+export const useInfiniteGetAtomsCountQuery = <
+  TData = InfiniteData<GetAtomsCountQuery>,
+  TError = unknown
+>(
+  variables: GetAtomsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAtomsCount.infinite"]
+            : ["GetAtomsCount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomsCountQuery, GetAtomsCountQueryVariables>(
+            GetAtomsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomsCountQuery.getKey = (
+  variables?: GetAtomsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomsCount.infinite"]
+    : ["GetAtomsCount.infinite", variables]
+
+useGetAtomsCountQuery.fetcher = (
+  variables?: GetAtomsCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomsCountQuery, GetAtomsCountQueryVariables>(
+    GetAtomsCountDocument,
+    variables,
+    options
+  )
+
+export const GetAtomDocument = `
+    query GetAtom($id: numeric!) {
+  atom(term_id: $id) {
+    ...AtomMetadata
+    ...AtomTxn
+    ...AtomVaultDetails
+    creator {
+      ...AccountMetadata
+    }
+    ...AtomTriple
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomTxnFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
+${AccountMetadataFragmentDoc}
+${AtomTripleFragmentDoc}`
+
+export const useGetAtomQuery = <TData = GetAtomQuery, TError = unknown>(
+  variables: GetAtomQueryVariables,
+  options?: Omit<UseQueryOptions<GetAtomQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetAtomQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomQuery, TError, TData>({
+    queryKey: ["GetAtom", variables],
+    queryFn: fetcher<GetAtomQuery, GetAtomQueryVariables>(
+      GetAtomDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomQuery.document = GetAtomDocument
+
+useGetAtomQuery.getKey = (variables: GetAtomQueryVariables) => [
+  "GetAtom",
+  variables
+]
+
+export const useInfiniteGetAtomQuery = <
+  TData = InfiniteData<GetAtomQuery>,
+  TError = unknown
+>(
+  variables: GetAtomQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetAtomQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAtom.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomQuery, GetAtomQueryVariables>(GetAtomDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomQuery.getKey = (variables: GetAtomQueryVariables) => [
+  "GetAtom.infinite",
+  variables
+]
+
+useGetAtomQuery.fetcher = (
+  variables: GetAtomQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomQuery, GetAtomQueryVariables>(
+    GetAtomDocument,
+    variables,
+    options
+  )
+
+export const GetAtomByDataDocument = `
+    query GetAtomByData($data: String!) {
+  atoms(where: {data: {_eq: $data}}) {
+    ...AtomMetadata
+    ...AtomTxn
+    ...AtomVaultDetails
+    creator {
+      ...AccountMetadata
+    }
+    ...AtomTriple
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AtomTxnFragmentDoc}
+${AtomVaultDetailsFragmentDoc}
+${AccountMetadataFragmentDoc}
+${AtomTripleFragmentDoc}`
+
+export const useGetAtomByDataQuery = <
+  TData = GetAtomByDataQuery,
+  TError = unknown
+>(
+  variables: GetAtomByDataQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomByDataQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAtomByDataQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomByDataQuery, TError, TData>({
+    queryKey: ["GetAtomByData", variables],
+    queryFn: fetcher<GetAtomByDataQuery, GetAtomByDataQueryVariables>(
+      GetAtomByDataDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomByDataQuery.document = GetAtomByDataDocument
+
+useGetAtomByDataQuery.getKey = (variables: GetAtomByDataQueryVariables) => [
+  "GetAtomByData",
+  variables
+]
+
+export const useInfiniteGetAtomByDataQuery = <
+  TData = InfiniteData<GetAtomByDataQuery>,
+  TError = unknown
+>(
+  variables: GetAtomByDataQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomByDataQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomByDataQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomByDataQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAtomByData.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomByDataQuery, GetAtomByDataQueryVariables>(
+            GetAtomByDataDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomByDataQuery.getKey = (
+  variables: GetAtomByDataQueryVariables
+) => ["GetAtomByData.infinite", variables]
+
+useGetAtomByDataQuery.fetcher = (
+  variables: GetAtomByDataQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomByDataQuery, GetAtomByDataQueryVariables>(
+    GetAtomByDataDocument,
+    variables,
+    options
+  )
+
+export const GetVerifiedAtomDetailsDocument = `
+    query GetVerifiedAtomDetails($id: numeric!, $userPositionAddress: String!) {
+  atom(term_id: $id) {
+    term_id
+    label
+    wallet_id
+    image
+    type
+    block_timestamp
+    data
+    creator {
+      id
+    }
+    value {
+      thing {
+        name
+        description
+        url
+      }
+    }
+    term {
+      vaults(where: {curve_id: {_eq: "1"}, term_id: {_eq: $id}}) {
+        current_share_price
+        total_shares
+        position_count
+        userPosition: positions(
+          limit: 1
+          where: {account_id: {_eq: $userPositionAddress}}
+        ) {
+          shares
+          account_id
+        }
+      }
+    }
+    tags: as_subject_triples_aggregate(where: {predicate_id: {_in: [3]}}) {
+      nodes {
+        object {
+          label
+          term {
+            vaults(where: {curve_id: {_eq: "1"}, term_id: {_eq: $id}}) {
+              term_id
+            }
+          }
+        }
+        predicate_id
+      }
+      aggregate {
+        count
+      }
+    }
+    verificationTriple: as_subject_triples_aggregate(
+      where: {predicate_id: {_eq: "4"}, object_id: {_eq: "126451"}}
+    ) {
+      nodes {
+        term_id
+        predicate_id
+        object_id
+        term {
+          vaults(where: {curve_id: {_eq: "1"}}) {
+            term_id
+            positions(
+              where: {account_id: {_in: ["0xd99811847e634d33f0dace483c52949bec76300f", "0xbb285b543c96c927fc320fb28524899c2c90806c", "0x0b162525c5dc8c18f771e60fd296913030bfe42c", "0xbd2de08af9470c87c4475117fb912b8f1d588d9c", "0xb95ca3d3144e9d1daff0ee3d35a4488a4a5c9fc5"]}}
+            ) {
+              id
+              shares
+              account_id
+              account {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetVerifiedAtomDetailsQuery = <
+  TData = GetVerifiedAtomDetailsQuery,
+  TError = unknown
+>(
+  variables: GetVerifiedAtomDetailsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetVerifiedAtomDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetVerifiedAtomDetailsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetVerifiedAtomDetailsQuery, TError, TData>({
+    queryKey: ["GetVerifiedAtomDetails", variables],
+    queryFn: fetcher<
+      GetVerifiedAtomDetailsQuery,
+      GetVerifiedAtomDetailsQueryVariables
+    >(GetVerifiedAtomDetailsDocument, variables),
+    ...options
+  })
+}
+
+useGetVerifiedAtomDetailsQuery.document = GetVerifiedAtomDetailsDocument
+
+useGetVerifiedAtomDetailsQuery.getKey = (
+  variables: GetVerifiedAtomDetailsQueryVariables
+) => ["GetVerifiedAtomDetails", variables]
+
+export const useInfiniteGetVerifiedAtomDetailsQuery = <
+  TData = InfiniteData<GetVerifiedAtomDetailsQuery>,
+  TError = unknown
+>(
+  variables: GetVerifiedAtomDetailsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetVerifiedAtomDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetVerifiedAtomDetailsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetVerifiedAtomDetailsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetVerifiedAtomDetails.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetVerifiedAtomDetailsQuery,
+            GetVerifiedAtomDetailsQueryVariables
+          >(GetVerifiedAtomDetailsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetVerifiedAtomDetailsQuery.getKey = (
+  variables: GetVerifiedAtomDetailsQueryVariables
+) => ["GetVerifiedAtomDetails.infinite", variables]
+
+useGetVerifiedAtomDetailsQuery.fetcher = (
+  variables: GetVerifiedAtomDetailsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetVerifiedAtomDetailsQuery, GetVerifiedAtomDetailsQueryVariables>(
+    GetVerifiedAtomDetailsDocument,
+    variables,
+    options
+  )
+
+export const GetAtomDetailsDocument = `
+    query GetAtomDetails($id: numeric!, $userPositionAddress: String!) {
+  atom(term_id: $id) {
+    term_id
+    label
+    wallet_id
+    image
+    type
+    block_timestamp
+    data
+    creator {
+      id
+    }
+    value {
+      thing {
+        name
+        description
+        url
+      }
+    }
+    term {
+      vaults(where: {curve_id: {_eq: "1"}, term_id: {_eq: $id}}) {
+        current_share_price
+        total_shares
+        position_count
+        userPosition: positions(
+          limit: 1
+          where: {account_id: {_eq: $userPositionAddress}}
+        ) {
+          shares
+          account_id
+        }
+      }
+    }
+    tags: as_subject_triples_aggregate(where: {predicate_id: {_in: [3]}}) {
+      nodes {
+        object {
+          label
+          term {
+            vaults(where: {curve_id: {_eq: "1"}, term_id: {_eq: $id}}) {
+              term_id
+            }
+          }
+        }
+        predicate_id
+      }
+      aggregate {
+        count
+      }
+    }
+  }
+}
+    `
+
+export const useGetAtomDetailsQuery = <
+  TData = GetAtomDetailsQuery,
+  TError = unknown
+>(
+  variables: GetAtomDetailsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAtomDetailsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomDetailsQuery, TError, TData>({
+    queryKey: ["GetAtomDetails", variables],
+    queryFn: fetcher<GetAtomDetailsQuery, GetAtomDetailsQueryVariables>(
+      GetAtomDetailsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomDetailsQuery.document = GetAtomDetailsDocument
+
+useGetAtomDetailsQuery.getKey = (variables: GetAtomDetailsQueryVariables) => [
+  "GetAtomDetails",
+  variables
+]
+
+export const useInfiniteGetAtomDetailsQuery = <
+  TData = InfiniteData<GetAtomDetailsQuery>,
+  TError = unknown
+>(
+  variables: GetAtomDetailsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomDetailsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomDetailsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAtomDetails.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomDetailsQuery, GetAtomDetailsQueryVariables>(
+            GetAtomDetailsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomDetailsQuery.getKey = (
+  variables: GetAtomDetailsQueryVariables
+) => ["GetAtomDetails.infinite", variables]
+
+useGetAtomDetailsQuery.fetcher = (
+  variables: GetAtomDetailsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomDetailsQuery, GetAtomDetailsQueryVariables>(
+    GetAtomDetailsDocument,
+    variables,
+    options
+  )
+
+export const GetAtomsByCreatorDocument = `
+    query GetAtomsByCreator($address: String!) {
+  atoms(where: {creator: {id: {_eq: $address}}}) {
+    term_id
+    data
+    image
+    label
+    type
+    block_number
+    block_timestamp
+    transaction_hash
+    creator_id
+    value {
+      thing {
+        name
+        image
+        description
+        url
+      }
+    }
+    term {
+      vaults {
+        position_count
+      }
+      total_market_cap
+    }
+    as_subject_triples_aggregate {
+      nodes {
+        predicate {
+          label
+          term_id
+        }
+        object {
+          label
+          term_id
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetAtomsByCreatorQuery = <
+  TData = GetAtomsByCreatorQuery,
+  TError = unknown
+>(
+  variables: GetAtomsByCreatorQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomsByCreatorQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAtomsByCreatorQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomsByCreatorQuery, TError, TData>({
+    queryKey: ["GetAtomsByCreator", variables],
+    queryFn: fetcher<GetAtomsByCreatorQuery, GetAtomsByCreatorQueryVariables>(
+      GetAtomsByCreatorDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAtomsByCreatorQuery.document = GetAtomsByCreatorDocument
+
+useGetAtomsByCreatorQuery.getKey = (
+  variables: GetAtomsByCreatorQueryVariables
+) => ["GetAtomsByCreator", variables]
+
+export const useInfiniteGetAtomsByCreatorQuery = <
+  TData = InfiniteData<GetAtomsByCreatorQuery>,
+  TError = unknown
+>(
+  variables: GetAtomsByCreatorQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomsByCreatorQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomsByCreatorQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomsByCreatorQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAtomsByCreator.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAtomsByCreatorQuery, GetAtomsByCreatorQueryVariables>(
+            GetAtomsByCreatorDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomsByCreatorQuery.getKey = (
+  variables: GetAtomsByCreatorQueryVariables
+) => ["GetAtomsByCreator.infinite", variables]
+
+useGetAtomsByCreatorQuery.fetcher = (
+  variables: GetAtomsByCreatorQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAtomsByCreatorQuery, GetAtomsByCreatorQueryVariables>(
+    GetAtomsByCreatorDocument,
+    variables,
+    options
+  )
+
+export const GetClaimsByAddressDocument = `
+    query GetClaimsByAddress($address: String) {
+  claims_aggregate(where: {account_id: {_eq: $address}}) {
+    aggregate {
+      count
+    }
+    nodes {
+      account {
+        label
+      }
+      position {
+        term {
+          triple {
+            subject {
+              label
+            }
+            predicate {
+              label
+            }
+            object {
+              label
+            }
+            term_id
+            counter_term_id
+          }
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetClaimsByAddressQuery = <
+  TData = GetClaimsByAddressQuery,
+  TError = unknown
+>(
+  variables?: GetClaimsByAddressQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetClaimsByAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetClaimsByAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetClaimsByAddressQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetClaimsByAddress"]
+        : ["GetClaimsByAddress", variables],
+    queryFn: fetcher<GetClaimsByAddressQuery, GetClaimsByAddressQueryVariables>(
+      GetClaimsByAddressDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetClaimsByAddressQuery.document = GetClaimsByAddressDocument
+
+useGetClaimsByAddressQuery.getKey = (
+  variables?: GetClaimsByAddressQueryVariables
+) =>
+  variables === undefined
+    ? ["GetClaimsByAddress"]
+    : ["GetClaimsByAddress", variables]
+
+export const useInfiniteGetClaimsByAddressQuery = <
+  TData = InfiniteData<GetClaimsByAddressQuery>,
+  TError = unknown
+>(
+  variables: GetClaimsByAddressQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetClaimsByAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetClaimsByAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetClaimsByAddressQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetClaimsByAddress.infinite"]
+            : ["GetClaimsByAddress.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetClaimsByAddressQuery, GetClaimsByAddressQueryVariables>(
+            GetClaimsByAddressDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetClaimsByAddressQuery.getKey = (
+  variables?: GetClaimsByAddressQueryVariables
+) =>
+  variables === undefined
+    ? ["GetClaimsByAddress.infinite"]
+    : ["GetClaimsByAddress.infinite", variables]
+
+useGetClaimsByAddressQuery.fetcher = (
+  variables?: GetClaimsByAddressQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetClaimsByAddressQuery, GetClaimsByAddressQueryVariables>(
+    GetClaimsByAddressDocument,
+    variables,
+    options
+  )
+
+export const GetClaimsByUriDocument = `
+    query GetClaimsByUri($address: String, $uri: String) {
+  atoms(
+    where: {_or: [{data: {_eq: $uri}}, {value: {thing: {url: {_eq: $uri}}}}, {value: {person: {url: {_eq: $uri}}}}, {value: {organization: {url: {_eq: $uri}}}}, {value: {book: {url: {_eq: $uri}}}}]}
+  ) {
+    as_subject_triples_aggregate {
+      aggregate {
+        count
+      }
+      nodes {
+        term_id
+        predicate {
+          label
+          image
+          type
+          term_id
+        }
+        object {
+          label
+          image
+          type
+          term_id
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        counter_positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        counter_positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        creator {
+          label
+          id
+          type
+        }
+      }
+    }
+    as_object_triples_aggregate {
+      aggregate {
+        count
+      }
+      nodes {
+        term_id
+        predicate {
+          label
+          image
+          type
+          term_id
+        }
+        subject {
+          label
+          image
+          type
+          term_id
+        }
+        object {
+          label
+          image
+          type
+          term_id
+        }
+        positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        counter_positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        counter_positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        creator {
+          label
+          id
+          type
+        }
+      }
+    }
+    as_predicate_triples_aggregate {
+      aggregate {
+        count
+      }
+      nodes {
+        term_id
+        predicate {
+          image
+          label
+          type
+          term_id
+        }
+        subject {
+          label
+          image
+          type
+          term_id
+        }
+        object {
+          label
+          image
+          type
+          term_id
+        }
+        positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        counter_positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        counter_positions(where: {account_id: {_eq: $address}}) {
+          shares
+        }
+        creator {
+          label
+          id
+          type
+        }
+      }
+    }
+    term_id
+    label
+    image
+    positions_aggregate {
+      aggregate {
+        count
+      }
+    }
+    value {
+      thing {
+        description
+        url
+      }
+    }
+  }
+}
+    `
+
+export const useGetClaimsByUriQuery = <
+  TData = GetClaimsByUriQuery,
+  TError = unknown
+>(
+  variables?: GetClaimsByUriQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetClaimsByUriQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetClaimsByUriQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetClaimsByUriQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetClaimsByUri"]
+        : ["GetClaimsByUri", variables],
+    queryFn: fetcher<GetClaimsByUriQuery, GetClaimsByUriQueryVariables>(
+      GetClaimsByUriDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetClaimsByUriQuery.document = GetClaimsByUriDocument
+
+useGetClaimsByUriQuery.getKey = (variables?: GetClaimsByUriQueryVariables) =>
+  variables === undefined ? ["GetClaimsByUri"] : ["GetClaimsByUri", variables]
+
+export const useInfiniteGetClaimsByUriQuery = <
+  TData = InfiniteData<GetClaimsByUriQuery>,
+  TError = unknown
+>(
+  variables: GetClaimsByUriQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetClaimsByUriQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetClaimsByUriQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetClaimsByUriQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetClaimsByUri.infinite"]
+            : ["GetClaimsByUri.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetClaimsByUriQuery, GetClaimsByUriQueryVariables>(
+            GetClaimsByUriDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetClaimsByUriQuery.getKey = (
+  variables?: GetClaimsByUriQueryVariables
+) =>
+  variables === undefined
+    ? ["GetClaimsByUri.infinite"]
+    : ["GetClaimsByUri.infinite", variables]
+
+useGetClaimsByUriQuery.fetcher = (
+  variables?: GetClaimsByUriQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetClaimsByUriQuery, GetClaimsByUriQueryVariables>(
+    GetClaimsByUriDocument,
+    variables,
+    options
+  )
+
+export const GetEventsDocument = `
+    query GetEvents($limit: Int, $offset: Int, $orderBy: [events_order_by!], $where: events_bool_exp, $addresses: [String!]) {
+  total: events_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  events(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    id
+    block_number
+    block_timestamp
+    type
+    transaction_hash
+    atom_id
+    triple_id
+    deposit_id
+    redemption_id
+    atom {
+      ...AtomMetadata
+      term {
+        vaults(where: {curve_id: {_eq: "1"}}) {
+          total_shares
+          position_count
+          positions(where: {account: {id: {_in: $addresses}}}) {
+            account_id
+            shares
+            account {
+              id
+              label
+              image
+            }
+          }
+        }
+      }
+    }
+    triple {
+      term_id
+      creator {
+        ...AccountMetadata
+      }
+      subject {
+        data
+        term_id
+        image
+        label
+        emoji
+        type
+        ...AtomValue
+        creator {
+          ...AccountMetadata
+        }
+      }
+      predicate {
+        data
+        term_id
+        image
+        label
+        emoji
+        type
+        ...AtomValue
+        creator {
+          ...AccountMetadata
+        }
+      }
+      object {
+        data
+        term_id
+        image
+        label
+        emoji
+        type
+        ...AtomValue
+        creator {
+          ...AccountMetadata
+        }
+      }
+      term {
+        vaults(where: {curve_id: {_eq: "1"}}) {
+          total_shares
+          position_count
+          positions(where: {account: {id: {_in: $addresses}}}) {
+            account_id
+            shares
+            account {
+              id
+              label
+              image
+            }
+          }
+        }
+      }
+      counter_term {
+        vaults(where: {curve_id: {_eq: "1"}}) {
+          total_shares
+          position_count
+          positions(where: {account: {id: {_in: $addresses}}}) {
+            account_id
+            shares
+            account {
+              id
+              label
+              image
+            }
+          }
+        }
+      }
+    }
+    deposit {
+      sender_id
+      sender {
+        id
+      }
+      shares_for_receiver
+      sender_assets_after_total_fees
+      vault {
+        total_shares
+        position_count
+        positions(where: {account: {id: {_in: $addresses}}}) {
+          account_id
+          shares
+          account {
+            id
+            label
+            image
+          }
+        }
+      }
+    }
+    redemption {
+      sender_id
+      sender {
+        id
+      }
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetEventsQuery = <TData = GetEventsQuery, TError = unknown>(
+  variables?: GetEventsQueryVariables,
+  options?: Omit<UseQueryOptions<GetEventsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetEventsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetEventsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetEvents"] : ["GetEvents", variables],
+    queryFn: fetcher<GetEventsQuery, GetEventsQueryVariables>(
+      GetEventsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetEventsQuery.document = GetEventsDocument
+
+useGetEventsQuery.getKey = (variables?: GetEventsQueryVariables) =>
+  variables === undefined ? ["GetEvents"] : ["GetEvents", variables]
+
+export const useInfiniteGetEventsQuery = <
+  TData = InfiniteData<GetEventsQuery>,
+  TError = unknown
+>(
+  variables: GetEventsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetEventsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetEventsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetEventsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetEvents.infinite"]
+            : ["GetEvents.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetEventsQuery, GetEventsQueryVariables>(GetEventsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetEventsQuery.getKey = (variables?: GetEventsQueryVariables) =>
+  variables === undefined
+    ? ["GetEvents.infinite"]
+    : ["GetEvents.infinite", variables]
+
+useGetEventsQuery.fetcher = (
+  variables?: GetEventsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetEventsQuery, GetEventsQueryVariables>(
+    GetEventsDocument,
+    variables,
+    options
+  )
+
+export const GetEventsWithAggregatesDocument = `
+    query GetEventsWithAggregates($limit: Int, $offset: Int, $orderBy: [events_order_by!], $where: events_bool_exp, $addresses: [String!]) {
+  events_aggregate(
+    where: $where
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
+    aggregate {
+      count
+      max {
+        block_timestamp
+        block_number
+      }
+      min {
+        block_timestamp
+        block_number
+      }
+    }
+    nodes {
+      ...EventDetails
+    }
+  }
+}
+    ${EventDetailsFragmentDoc}
+${DepositEventFragmentFragmentDoc}
+${RedemptionEventFragmentFragmentDoc}
+${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${TripleMetadataFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}`
+
+export const useGetEventsWithAggregatesQuery = <
+  TData = GetEventsWithAggregatesQuery,
+  TError = unknown
+>(
+  variables?: GetEventsWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetEventsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetEventsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetEventsWithAggregatesQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetEventsWithAggregates"]
+        : ["GetEventsWithAggregates", variables],
+    queryFn: fetcher<
+      GetEventsWithAggregatesQuery,
+      GetEventsWithAggregatesQueryVariables
+    >(GetEventsWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetEventsWithAggregatesQuery.document = GetEventsWithAggregatesDocument
+
+useGetEventsWithAggregatesQuery.getKey = (
+  variables?: GetEventsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetEventsWithAggregates"]
+    : ["GetEventsWithAggregates", variables]
+
+export const useInfiniteGetEventsWithAggregatesQuery = <
+  TData = InfiniteData<GetEventsWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetEventsWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetEventsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetEventsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetEventsWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetEventsWithAggregates.infinite"]
+            : ["GetEventsWithAggregates.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetEventsWithAggregatesQuery,
+            GetEventsWithAggregatesQueryVariables
+          >(GetEventsWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetEventsWithAggregatesQuery.getKey = (
+  variables?: GetEventsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetEventsWithAggregates.infinite"]
+    : ["GetEventsWithAggregates.infinite", variables]
+
+useGetEventsWithAggregatesQuery.fetcher = (
+  variables?: GetEventsWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetEventsWithAggregatesQuery, GetEventsWithAggregatesQueryVariables>(
+    GetEventsWithAggregatesDocument,
+    variables,
+    options
+  )
+
+export const GetEventsCountDocument = `
+    query GetEventsCount($where: events_bool_exp) {
+  events_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetEventsCountQuery = <
+  TData = GetEventsCountQuery,
+  TError = unknown
+>(
+  variables?: GetEventsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetEventsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetEventsCountQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetEventsCountQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetEventsCount"]
+        : ["GetEventsCount", variables],
+    queryFn: fetcher<GetEventsCountQuery, GetEventsCountQueryVariables>(
+      GetEventsCountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetEventsCountQuery.document = GetEventsCountDocument
+
+useGetEventsCountQuery.getKey = (variables?: GetEventsCountQueryVariables) =>
+  variables === undefined ? ["GetEventsCount"] : ["GetEventsCount", variables]
+
+export const useInfiniteGetEventsCountQuery = <
+  TData = InfiniteData<GetEventsCountQuery>,
+  TError = unknown
+>(
+  variables: GetEventsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetEventsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetEventsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetEventsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetEventsCount.infinite"]
+            : ["GetEventsCount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetEventsCountQuery, GetEventsCountQueryVariables>(
+            GetEventsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetEventsCountQuery.getKey = (
+  variables?: GetEventsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetEventsCount.infinite"]
+    : ["GetEventsCount.infinite", variables]
+
+useGetEventsCountQuery.fetcher = (
+  variables?: GetEventsCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetEventsCountQuery, GetEventsCountQueryVariables>(
+    GetEventsCountDocument,
+    variables,
+    options
+  )
+
+export const GetEventsDataDocument = `
+    query GetEventsData($where: events_bool_exp) {
+  events_aggregate(where: $where) {
+    aggregate {
+      count
+      max {
+        block_timestamp
+        block_number
+      }
+      min {
+        block_timestamp
+        block_number
+      }
+      avg {
+        block_number
+      }
+    }
+  }
+}
+    `
+
+export const useGetEventsDataQuery = <
+  TData = GetEventsDataQuery,
+  TError = unknown
+>(
+  variables?: GetEventsDataQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetEventsDataQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetEventsDataQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetEventsDataQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetEventsData"]
+        : ["GetEventsData", variables],
+    queryFn: fetcher<GetEventsDataQuery, GetEventsDataQueryVariables>(
+      GetEventsDataDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetEventsDataQuery.document = GetEventsDataDocument
+
+useGetEventsDataQuery.getKey = (variables?: GetEventsDataQueryVariables) =>
+  variables === undefined ? ["GetEventsData"] : ["GetEventsData", variables]
+
+export const useInfiniteGetEventsDataQuery = <
+  TData = InfiniteData<GetEventsDataQuery>,
+  TError = unknown
+>(
+  variables: GetEventsDataQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetEventsDataQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetEventsDataQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetEventsDataQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetEventsData.infinite"]
+            : ["GetEventsData.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetEventsDataQuery, GetEventsDataQueryVariables>(
+            GetEventsDataDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetEventsDataQuery.getKey = (
+  variables?: GetEventsDataQueryVariables
+) =>
+  variables === undefined
+    ? ["GetEventsData.infinite"]
+    : ["GetEventsData.infinite", variables]
+
+useGetEventsDataQuery.fetcher = (
+  variables?: GetEventsDataQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetEventsDataQuery, GetEventsDataQueryVariables>(
+    GetEventsDataDocument,
+    variables,
+    options
+  )
+
+export const GetDebugEventsDocument = `
+    query GetDebugEvents($addresses: [String!]) {
+  debug_events: events {
+    id
+    atom {
+      term {
+        positions(where: {account_id: {_in: $addresses}}) {
+          account_id
+          shares
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetDebugEventsQuery = <
+  TData = GetDebugEventsQuery,
+  TError = unknown
+>(
+  variables?: GetDebugEventsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetDebugEventsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetDebugEventsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetDebugEventsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetDebugEvents"]
+        : ["GetDebugEvents", variables],
+    queryFn: fetcher<GetDebugEventsQuery, GetDebugEventsQueryVariables>(
+      GetDebugEventsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetDebugEventsQuery.document = GetDebugEventsDocument
+
+useGetDebugEventsQuery.getKey = (variables?: GetDebugEventsQueryVariables) =>
+  variables === undefined ? ["GetDebugEvents"] : ["GetDebugEvents", variables]
+
+export const useInfiniteGetDebugEventsQuery = <
+  TData = InfiniteData<GetDebugEventsQuery>,
+  TError = unknown
+>(
+  variables: GetDebugEventsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetDebugEventsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetDebugEventsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetDebugEventsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetDebugEvents.infinite"]
+            : ["GetDebugEvents.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetDebugEventsQuery, GetDebugEventsQueryVariables>(
+            GetDebugEventsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetDebugEventsQuery.getKey = (
+  variables?: GetDebugEventsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetDebugEvents.infinite"]
+    : ["GetDebugEvents.infinite", variables]
+
+useGetDebugEventsQuery.fetcher = (
+  variables?: GetDebugEventsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetDebugEventsQuery, GetDebugEventsQueryVariables>(
+    GetDebugEventsDocument,
+    variables,
+    options
+  )
+
+export const GetFollowingPositionsDocument = `
+    query GetFollowingPositions($subjectId: numeric!, $predicateId: numeric!, $address: String!, $limit: Int, $offset: Int, $positionsOrderBy: [positions_order_by!]) {
+  triples_aggregate(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {positions: {account_id: {_eq: $address}}}]}
+  ) {
+    aggregate {
+      count
+    }
+  }
+  triples(
+    limit: $limit
+    offset: $offset
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {positions: {account_id: {_eq: $address}}}]}
+  ) {
+    term_id
+    subject {
+      ...AtomMetadata
+    }
+    predicate {
+      ...AtomMetadata
+    }
+    object {
+      ...AtomMetadata
+    }
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        current_share_price
+        positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}, order_by: $positionsOrderBy) {
+          account_id
+          account {
+            id
+            label
+          }
+          shares
+        }
+      }
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}`
+
+export const useGetFollowingPositionsQuery = <
+  TData = GetFollowingPositionsQuery,
+  TError = unknown
+>(
+  variables: GetFollowingPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFollowingPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetFollowingPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetFollowingPositionsQuery, TError, TData>({
+    queryKey: ["GetFollowingPositions", variables],
+    queryFn: fetcher<
+      GetFollowingPositionsQuery,
+      GetFollowingPositionsQueryVariables
+    >(GetFollowingPositionsDocument, variables),
+    ...options
+  })
+}
+
+useGetFollowingPositionsQuery.document = GetFollowingPositionsDocument
+
+useGetFollowingPositionsQuery.getKey = (
+  variables: GetFollowingPositionsQueryVariables
+) => ["GetFollowingPositions", variables]
+
+export const useInfiniteGetFollowingPositionsQuery = <
+  TData = InfiniteData<GetFollowingPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetFollowingPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFollowingPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFollowingPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFollowingPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetFollowingPositions.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetFollowingPositionsQuery,
+            GetFollowingPositionsQueryVariables
+          >(GetFollowingPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFollowingPositionsQuery.getKey = (
+  variables: GetFollowingPositionsQueryVariables
+) => ["GetFollowingPositions.infinite", variables]
+
+useGetFollowingPositionsQuery.fetcher = (
+  variables: GetFollowingPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetFollowingPositionsQuery, GetFollowingPositionsQueryVariables>(
+    GetFollowingPositionsDocument,
+    variables,
+    options
+  )
+
+export const GetFollowerPositionsDocument = `
+    query GetFollowerPositions($subjectId: numeric!, $predicateId: numeric!, $objectId: numeric!, $positionsLimit: Int, $positionsOffset: Int, $positionsOrderBy: [positions_order_by!], $positionsWhere: positions_bool_exp) {
+  triples(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {object_id: {_eq: $objectId}}]}
+  ) {
+    term_id
+    subject {
+      ...AtomMetadata
+    }
+    predicate {
+      ...AtomMetadata
+    }
+    object {
+      ...AtomMetadata
+    }
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        total_shares
+        current_share_price
+        positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+        positions(
+          limit: $positionsLimit
+          offset: $positionsOffset
+          order_by: $positionsOrderBy
+          where: $positionsWhere
+        ) {
+          account {
+            id
+            label
+            image
+          }
+          shares
+        }
+      }
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}`
+
+export const useGetFollowerPositionsQuery = <
+  TData = GetFollowerPositionsQuery,
+  TError = unknown
+>(
+  variables: GetFollowerPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFollowerPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetFollowerPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetFollowerPositionsQuery, TError, TData>({
+    queryKey: ["GetFollowerPositions", variables],
+    queryFn: fetcher<
+      GetFollowerPositionsQuery,
+      GetFollowerPositionsQueryVariables
+    >(GetFollowerPositionsDocument, variables),
+    ...options
+  })
+}
+
+useGetFollowerPositionsQuery.document = GetFollowerPositionsDocument
+
+useGetFollowerPositionsQuery.getKey = (
+  variables: GetFollowerPositionsQueryVariables
+) => ["GetFollowerPositions", variables]
+
+export const useInfiniteGetFollowerPositionsQuery = <
+  TData = InfiniteData<GetFollowerPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetFollowerPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFollowerPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFollowerPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFollowerPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetFollowerPositions.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetFollowerPositionsQuery,
+            GetFollowerPositionsQueryVariables
+          >(GetFollowerPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFollowerPositionsQuery.getKey = (
+  variables: GetFollowerPositionsQueryVariables
+) => ["GetFollowerPositions.infinite", variables]
+
+useGetFollowerPositionsQuery.fetcher = (
+  variables: GetFollowerPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetFollowerPositionsQuery, GetFollowerPositionsQueryVariables>(
+    GetFollowerPositionsDocument,
+    variables,
+    options
+  )
+
+export const GetConnectionsDocument = `
+    query GetConnections($subjectId: numeric!, $predicateId: numeric!, $objectId: numeric!, $addresses: [String!], $positionsLimit: Int, $positionsOffset: Int, $positionsOrderBy: [positions_order_by!], $positionsWhere: positions_bool_exp) {
+  following_count: triples_aggregate(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {object_id: {_eq: $objectId}}]}
+  ) {
+    aggregate {
+      count
+    }
+  }
+  following: triples(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {object_id: {_eq: $objectId}}]}
+  ) {
+    ...FollowMetadata
+  }
+  followers_count: triples_aggregate(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {positions: {account_id: {_in: $addresses}}}]}
+  ) {
+    aggregate {
+      count
+    }
+  }
+  followers: triples(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {positions: {account_id: {_in: $addresses}}}]}
+  ) {
+    ...FollowMetadata
+  }
+}
+    ${FollowMetadataFragmentDoc}`
+
+export const useGetConnectionsQuery = <
+  TData = GetConnectionsQuery,
+  TError = unknown
+>(
+  variables: GetConnectionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetConnectionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetConnectionsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetConnectionsQuery, TError, TData>({
+    queryKey: ["GetConnections", variables],
+    queryFn: fetcher<GetConnectionsQuery, GetConnectionsQueryVariables>(
+      GetConnectionsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetConnectionsQuery.document = GetConnectionsDocument
+
+useGetConnectionsQuery.getKey = (variables: GetConnectionsQueryVariables) => [
+  "GetConnections",
+  variables
+]
+
+export const useInfiniteGetConnectionsQuery = <
+  TData = InfiniteData<GetConnectionsQuery>,
+  TError = unknown
+>(
+  variables: GetConnectionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetConnectionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetConnectionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetConnectionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetConnections.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetConnectionsQuery, GetConnectionsQueryVariables>(
+            GetConnectionsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetConnectionsQuery.getKey = (
+  variables: GetConnectionsQueryVariables
+) => ["GetConnections.infinite", variables]
+
+useGetConnectionsQuery.fetcher = (
+  variables: GetConnectionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetConnectionsQuery, GetConnectionsQueryVariables>(
+    GetConnectionsDocument,
+    variables,
+    options
+  )
+
+export const GetConnectionsCountDocument = `
+    query GetConnectionsCount($subjectId: numeric!, $predicateId: numeric!, $objectId: numeric!, $address: String!) {
+  following_count: triples_aggregate(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {positions: {account_id: {_eq: $address}}}]}
+  ) {
+    aggregate {
+      count
+    }
+  }
+  followers_count: triples(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}, {object_id: {_eq: $objectId}}]}
+  ) {
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        positions_aggregate {
+          aggregate {
+            count
+            sum {
+              shares
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetConnectionsCountQuery = <
+  TData = GetConnectionsCountQuery,
+  TError = unknown
+>(
+  variables: GetConnectionsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetConnectionsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetConnectionsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetConnectionsCountQuery, TError, TData>({
+    queryKey: ["GetConnectionsCount", variables],
+    queryFn: fetcher<
+      GetConnectionsCountQuery,
+      GetConnectionsCountQueryVariables
+    >(GetConnectionsCountDocument, variables),
+    ...options
+  })
+}
+
+useGetConnectionsCountQuery.document = GetConnectionsCountDocument
+
+useGetConnectionsCountQuery.getKey = (
+  variables: GetConnectionsCountQueryVariables
+) => ["GetConnectionsCount", variables]
+
+export const useInfiniteGetConnectionsCountQuery = <
+  TData = InfiniteData<GetConnectionsCountQuery>,
+  TError = unknown
+>(
+  variables: GetConnectionsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetConnectionsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetConnectionsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetConnectionsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetConnectionsCount.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<GetConnectionsCountQuery, GetConnectionsCountQueryVariables>(
+            GetConnectionsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetConnectionsCountQuery.getKey = (
+  variables: GetConnectionsCountQueryVariables
+) => ["GetConnectionsCount.infinite", variables]
+
+useGetConnectionsCountQuery.fetcher = (
+  variables: GetConnectionsCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetConnectionsCountQuery, GetConnectionsCountQueryVariables>(
+    GetConnectionsCountDocument,
+    variables,
+    options
+  )
+
+export const GetFollowingsFromAddressDocument = `
+    query getFollowingsFromAddress($address: String!) {
+  following(args: {address: $address}) {
+    id
+    image
+    label
+    type
+    triples(order_by: {term_id: desc}) {
+      term_id
+      creator {
+        label
+        id
+        type
+      }
+      subject {
+        term_id
+        label
+        image
+        type
+      }
+      predicate {
+        term_id
+        label
+        image
+        type
+      }
+      object {
+        term_id
+        label
+        image
+        type
+      }
+      counter_term_id
+      term {
+        id
+        positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          shares
+          account {
+            id
+          }
+        }
+      }
+      counter_term {
+        id
+        positions_aggregate {
+          aggregate {
+            count
+          }
+        }
+        positions(where: {account_id: {_eq: $address}}) {
+          shares
+          account {
+            id
+          }
+        }
+      }
+    }
+    positions_aggregate(limit: 10) {
+      aggregate {
+        count
+      }
+      nodes {
+        shares
+        term {
+          id
+          triple {
+            term_id
+            object {
+              term_id
+              type
+              image
+              label
+            }
+            predicate {
+              term_id
+              type
+              image
+              label
+            }
+            subject {
+              term_id
+              type
+              image
+              label
+            }
+            counter_term {
+              id
+              positions_aggregate {
+                aggregate {
+                  count
+                }
+              }
+              positions(where: {account_id: {_eq: $address}}) {
+                shares
+                account {
+                  id
+                }
+              }
+            }
+            term {
+              id
+              positions_aggregate {
+                aggregate {
+                  count
+                }
+              }
+              positions(where: {account_id: {_eq: $address}}) {
+                shares
+                account {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetFollowingsFromAddressQuery = <
+  TData = GetFollowingsFromAddressQuery,
+  TError = unknown
+>(
+  variables: GetFollowingsFromAddressQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFollowingsFromAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetFollowingsFromAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetFollowingsFromAddressQuery, TError, TData>({
+    queryKey: ["getFollowingsFromAddress", variables],
+    queryFn: fetcher<
+      GetFollowingsFromAddressQuery,
+      GetFollowingsFromAddressQueryVariables
+    >(GetFollowingsFromAddressDocument, variables),
+    ...options
+  })
+}
+
+useGetFollowingsFromAddressQuery.document = GetFollowingsFromAddressDocument
+
+useGetFollowingsFromAddressQuery.getKey = (
+  variables: GetFollowingsFromAddressQueryVariables
+) => ["getFollowingsFromAddress", variables]
+
+export const useInfiniteGetFollowingsFromAddressQuery = <
+  TData = InfiniteData<GetFollowingsFromAddressQuery>,
+  TError = unknown
+>(
+  variables: GetFollowingsFromAddressQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFollowingsFromAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFollowingsFromAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFollowingsFromAddressQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "getFollowingsFromAddress.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetFollowingsFromAddressQuery,
+            GetFollowingsFromAddressQueryVariables
+          >(GetFollowingsFromAddressDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFollowingsFromAddressQuery.getKey = (
+  variables: GetFollowingsFromAddressQueryVariables
+) => ["getFollowingsFromAddress.infinite", variables]
+
+useGetFollowingsFromAddressQuery.fetcher = (
+  variables: GetFollowingsFromAddressQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetFollowingsFromAddressQuery,
+    GetFollowingsFromAddressQueryVariables
+  >(GetFollowingsFromAddressDocument, variables, options)
+
+export const GetFollowersFromAddressDocument = `
+    query getFollowersFromAddress($address: String!) {
+  triples(
+    where: {predicate: {label: {_eq: "follow"}}, object: {accounts: {id: {_eq: $address}}}}
+  ) {
+    term_id
+    predicate {
+      label
+    }
+    object {
+      term_id
+    }
+    term {
+      id
+      positions {
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
+    }
+    counter_term {
+      id
+      positions {
+        shares
+        account {
+          id
+          label
+          image
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetFollowersFromAddressQuery = <
+  TData = GetFollowersFromAddressQuery,
+  TError = unknown
+>(
+  variables: GetFollowersFromAddressQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFollowersFromAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetFollowersFromAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetFollowersFromAddressQuery, TError, TData>({
+    queryKey: ["getFollowersFromAddress", variables],
+    queryFn: fetcher<
+      GetFollowersFromAddressQuery,
+      GetFollowersFromAddressQueryVariables
+    >(GetFollowersFromAddressDocument, variables),
+    ...options
+  })
+}
+
+useGetFollowersFromAddressQuery.document = GetFollowersFromAddressDocument
+
+useGetFollowersFromAddressQuery.getKey = (
+  variables: GetFollowersFromAddressQueryVariables
+) => ["getFollowersFromAddress", variables]
+
+export const useInfiniteGetFollowersFromAddressQuery = <
+  TData = InfiniteData<GetFollowersFromAddressQuery>,
+  TError = unknown
+>(
+  variables: GetFollowersFromAddressQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFollowersFromAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFollowersFromAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFollowersFromAddressQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "getFollowersFromAddress.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetFollowersFromAddressQuery,
+            GetFollowersFromAddressQueryVariables
+          >(GetFollowersFromAddressDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFollowersFromAddressQuery.getKey = (
+  variables: GetFollowersFromAddressQueryVariables
+) => ["getFollowersFromAddress.infinite", variables]
+
+useGetFollowersFromAddressQuery.fetcher = (
+  variables: GetFollowersFromAddressQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetFollowersFromAddressQuery, GetFollowersFromAddressQueryVariables>(
+    GetFollowersFromAddressDocument,
+    variables,
+    options
+  )
+
+export const GetFollowingsTriplesDocument = `
+    query GetFollowingsTriples($accountId: String!) {
+  triples(
+    where: {predicate: {label: {_eq: "follow"}}, subject: {accounts: {id: {_eq: $accountId}}, type: {_eq: "Account"}}}
+  ) {
+    term_id
+    object {
+      term_id
+      label
+      type
+      image
+      accounts {
+        id
+      }
+    }
+  }
+}
+    `
+
+export const useGetFollowingsTriplesQuery = <
+  TData = GetFollowingsTriplesQuery,
+  TError = unknown
+>(
+  variables: GetFollowingsTriplesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFollowingsTriplesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetFollowingsTriplesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetFollowingsTriplesQuery, TError, TData>({
+    queryKey: ["GetFollowingsTriples", variables],
+    queryFn: fetcher<
+      GetFollowingsTriplesQuery,
+      GetFollowingsTriplesQueryVariables
+    >(GetFollowingsTriplesDocument, variables),
+    ...options
+  })
+}
+
+useGetFollowingsTriplesQuery.document = GetFollowingsTriplesDocument
+
+useGetFollowingsTriplesQuery.getKey = (
+  variables: GetFollowingsTriplesQueryVariables
+) => ["GetFollowingsTriples", variables]
+
+export const useInfiniteGetFollowingsTriplesQuery = <
+  TData = InfiniteData<GetFollowingsTriplesQuery>,
+  TError = unknown
+>(
+  variables: GetFollowingsTriplesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFollowingsTriplesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFollowingsTriplesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFollowingsTriplesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetFollowingsTriples.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetFollowingsTriplesQuery,
+            GetFollowingsTriplesQueryVariables
+          >(GetFollowingsTriplesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFollowingsTriplesQuery.getKey = (
+  variables: GetFollowingsTriplesQueryVariables
+) => ["GetFollowingsTriples.infinite", variables]
+
+useGetFollowingsTriplesQuery.fetcher = (
+  variables: GetFollowingsTriplesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetFollowingsTriplesQuery, GetFollowingsTriplesQueryVariables>(
+    GetFollowingsTriplesDocument,
+    variables,
+    options
+  )
+
+export const GetAccountByIdDocument = `
+    query GetAccountById($id: String!) {
+  account(id: $id) {
+    id
+    label
+    image
+  }
+}
+    `
+
+export const useGetAccountByIdQuery = <
+  TData = GetAccountByIdQuery,
+  TError = unknown
+>(
+  variables: GetAccountByIdQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAccountByIdQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetAccountByIdQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetAccountByIdQuery, TError, TData>({
+    queryKey: ["GetAccountById", variables],
+    queryFn: fetcher<GetAccountByIdQuery, GetAccountByIdQueryVariables>(
+      GetAccountByIdDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetAccountByIdQuery.document = GetAccountByIdDocument
+
+useGetAccountByIdQuery.getKey = (variables: GetAccountByIdQueryVariables) => [
+  "GetAccountById",
+  variables
+]
+
+export const useInfiniteGetAccountByIdQuery = <
+  TData = InfiniteData<GetAccountByIdQuery>,
+  TError = unknown
+>(
+  variables: GetAccountByIdQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAccountByIdQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAccountByIdQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAccountByIdQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetAccountById.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetAccountByIdQuery, GetAccountByIdQueryVariables>(
+            GetAccountByIdDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAccountByIdQuery.getKey = (
+  variables: GetAccountByIdQueryVariables
+) => ["GetAccountById.infinite", variables]
+
+useGetAccountByIdQuery.fetcher = (
+  variables: GetAccountByIdQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetAccountByIdQuery, GetAccountByIdQueryVariables>(
+    GetAccountByIdDocument,
+    variables,
+    options
+  )
+
+export const GetListsDocument = `
+    query GetLists($where: predicate_objects_bool_exp) {
+  predicate_objects_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  predicate_objects(
+    where: $where
+    order_by: [{claim_count: desc}, {triple_count: desc}]
+  ) {
+    id
+    claim_count
+    triple_count
+    object {
+      term_id
+      label
+      image
+    }
+  }
+}
+    `
+
+export const useGetListsQuery = <TData = GetListsQuery, TError = unknown>(
+  variables?: GetListsQueryVariables,
+  options?: Omit<UseQueryOptions<GetListsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetListsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetListsQuery, TError, TData>({
+    queryKey: variables === undefined ? ["GetLists"] : ["GetLists", variables],
+    queryFn: fetcher<GetListsQuery, GetListsQueryVariables>(
+      GetListsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetListsQuery.document = GetListsDocument
+
+useGetListsQuery.getKey = (variables?: GetListsQueryVariables) =>
+  variables === undefined ? ["GetLists"] : ["GetLists", variables]
+
+export const useInfiniteGetListsQuery = <
+  TData = InfiniteData<GetListsQuery>,
+  TError = unknown
+>(
+  variables: GetListsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetListsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetLists.infinite"]
+            : ["GetLists.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetListsQuery, GetListsQueryVariables>(GetListsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListsQuery.getKey = (variables?: GetListsQueryVariables) =>
+  variables === undefined
+    ? ["GetLists.infinite"]
+    : ["GetLists.infinite", variables]
+
+useGetListsQuery.fetcher = (
+  variables?: GetListsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetListsQuery, GetListsQueryVariables>(
+    GetListsDocument,
+    variables,
+    options
+  )
+
+export const GetListItemsDocument = `
+    query GetListItems($predicateId: numeric, $objectId: numeric) {
+  triples_aggregate(
+    where: {predicate_id: {_eq: predicateId}, object_id: {_eq: $objectId}}
+    order_by: [{term: {positions_aggregate: {count: desc}}, counter_term: {positions_aggregate: {count: desc}}}]
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      ...TripleVaultDetails
+    }
+  }
+}
+    ${TripleVaultDetailsFragmentDoc}
+${PositionDetailsFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetListItemsQuery = <
+  TData = GetListItemsQuery,
+  TError = unknown
+>(
+  variables?: GetListItemsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetListItemsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetListItemsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetListItemsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetListItems"] : ["GetListItems", variables],
+    queryFn: fetcher<GetListItemsQuery, GetListItemsQueryVariables>(
+      GetListItemsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetListItemsQuery.document = GetListItemsDocument
+
+useGetListItemsQuery.getKey = (variables?: GetListItemsQueryVariables) =>
+  variables === undefined ? ["GetListItems"] : ["GetListItems", variables]
+
+export const useInfiniteGetListItemsQuery = <
+  TData = InfiniteData<GetListItemsQuery>,
+  TError = unknown
+>(
+  variables: GetListItemsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListItemsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetListItemsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListItemsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetListItems.infinite"]
+            : ["GetListItems.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetListItemsQuery, GetListItemsQueryVariables>(
+            GetListItemsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListItemsQuery.getKey = (
+  variables?: GetListItemsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListItems.infinite"]
+    : ["GetListItems.infinite", variables]
+
+useGetListItemsQuery.fetcher = (
+  variables?: GetListItemsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetListItemsQuery, GetListItemsQueryVariables>(
+    GetListItemsDocument,
+    variables,
+    options
+  )
+
+export const GetListDetailsDocument = `
+    query GetListDetails($globalWhere: triples_bool_exp, $tagPredicateId: numeric, $limit: Int, $offset: Int, $orderBy: [triples_order_by!]) {
+  globalTriplesAggregate: triples_aggregate(where: $globalWhere) {
+    aggregate {
+      count
+    }
+  }
+  globalTriples: triples(
+    where: $globalWhere
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
+    term_id
+    counter_term_id
+    subject {
+      term_id
+      label
+      wallet_id
+      image
+      type
+      tags: as_subject_triples_aggregate(
+        where: {predicate_id: {_eq: $tagPredicateId}}
+      ) {
+        nodes {
+          object {
+            label
+            term_id
+            taggedIdentities: as_object_triples_aggregate {
+              nodes {
+                subject {
+                  label
+                  term_id
+                }
+                term_id
+              }
+              aggregate {
+                count
+              }
+            }
+          }
+        }
+        aggregate {
+          count
+        }
+      }
+    }
+    object {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    predicate {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        current_share_price
+        position_count
+        total_shares
+      }
+    }
+    counter_term {
+      vaults(where: {curve_id: {_eq: "1"}}) {
+        current_share_price
+        position_count
+        total_shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetListDetailsQuery = <
+  TData = GetListDetailsQuery,
+  TError = unknown
+>(
+  variables?: GetListDetailsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetListDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetListDetailsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetListDetailsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetListDetails"]
+        : ["GetListDetails", variables],
+    queryFn: fetcher<GetListDetailsQuery, GetListDetailsQueryVariables>(
+      GetListDetailsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetListDetailsQuery.document = GetListDetailsDocument
+
+useGetListDetailsQuery.getKey = (variables?: GetListDetailsQueryVariables) =>
+  variables === undefined ? ["GetListDetails"] : ["GetListDetails", variables]
+
+export const useInfiniteGetListDetailsQuery = <
+  TData = InfiniteData<GetListDetailsQuery>,
+  TError = unknown
+>(
+  variables: GetListDetailsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListDetailsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetListDetailsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListDetailsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetListDetails.infinite"]
+            : ["GetListDetails.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetListDetailsQuery, GetListDetailsQueryVariables>(
+            GetListDetailsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListDetailsQuery.getKey = (
+  variables?: GetListDetailsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListDetails.infinite"]
+    : ["GetListDetails.infinite", variables]
+
+useGetListDetailsQuery.fetcher = (
+  variables?: GetListDetailsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetListDetailsQuery, GetListDetailsQueryVariables>(
+    GetListDetailsDocument,
+    variables,
+    options
+  )
+
+export const GetListDetailsWithPositionDocument = `
+    query GetListDetailsWithPosition($globalWhere: triples_bool_exp, $tagPredicateId: numeric, $address: String, $limit: Int, $offset: Int, $orderBy: [triples_order_by!]) {
+  globalTriplesAggregate: triples_aggregate(where: $globalWhere) {
+    aggregate {
+      count
+    }
+  }
+  globalTriples: triples(
+    where: $globalWhere
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
+    term_id
+    counter_term_id
+    subject {
+      term_id
+      label
+      wallet_id
+      image
+      type
+      tags: as_subject_triples_aggregate(
+        where: {predicate_id: {_eq: $tagPredicateId}}
+      ) {
+        nodes {
+          object {
+            label
+            term_id
+            taggedIdentities: as_object_triples_aggregate {
+              nodes {
+                subject {
+                  label
+                  term_id
+                }
+                term_id
+              }
+              aggregate {
+                count
+              }
+            }
+          }
+        }
+        aggregate {
+          count
+        }
+      }
+    }
+    object {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    predicate {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+    counter_term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetListDetailsWithPositionQuery = <
+  TData = GetListDetailsWithPositionQuery,
+  TError = unknown
+>(
+  variables?: GetListDetailsWithPositionQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetListDetailsWithPositionQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetListDetailsWithPositionQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetListDetailsWithPositionQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetListDetailsWithPosition"]
+        : ["GetListDetailsWithPosition", variables],
+    queryFn: fetcher<
+      GetListDetailsWithPositionQuery,
+      GetListDetailsWithPositionQueryVariables
+    >(GetListDetailsWithPositionDocument, variables),
+    ...options
+  })
+}
+
+useGetListDetailsWithPositionQuery.document = GetListDetailsWithPositionDocument
+
+useGetListDetailsWithPositionQuery.getKey = (
+  variables?: GetListDetailsWithPositionQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListDetailsWithPosition"]
+    : ["GetListDetailsWithPosition", variables]
+
+export const useInfiniteGetListDetailsWithPositionQuery = <
+  TData = InfiniteData<GetListDetailsWithPositionQuery>,
+  TError = unknown
+>(
+  variables: GetListDetailsWithPositionQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListDetailsWithPositionQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetListDetailsWithPositionQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListDetailsWithPositionQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetListDetailsWithPosition.infinite"]
+            : ["GetListDetailsWithPosition.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetListDetailsWithPositionQuery,
+            GetListDetailsWithPositionQueryVariables
+          >(GetListDetailsWithPositionDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListDetailsWithPositionQuery.getKey = (
+  variables?: GetListDetailsWithPositionQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListDetailsWithPosition.infinite"]
+    : ["GetListDetailsWithPosition.infinite", variables]
+
+useGetListDetailsWithPositionQuery.fetcher = (
+  variables?: GetListDetailsWithPositionQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetListDetailsWithPositionQuery,
+    GetListDetailsWithPositionQueryVariables
+  >(GetListDetailsWithPositionDocument, variables, options)
+
+export const GetListDetailsWithUserDocument = `
+    query GetListDetailsWithUser($globalWhere: triples_bool_exp, $userWhere: triples_bool_exp, $tagPredicateId: numeric, $address: String, $limit: Int, $offset: Int, $orderBy: [triples_order_by!]) {
+  globalTriplesAggregate: triples_aggregate(where: $globalWhere) {
+    aggregate {
+      count
+    }
+  }
+  globalTriples: triples(
+    where: $globalWhere
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
+    term_id
+    counter_term_id
+    subject {
+      term_id
+      label
+      wallet_id
+      image
+      type
+      tags: as_subject_triples_aggregate(
+        where: {predicate_id: {_eq: $tagPredicateId}}
+      ) {
+        nodes {
+          object {
+            label
+            term_id
+            taggedIdentities: as_object_triples_aggregate {
+              nodes {
+                subject {
+                  label
+                  term_id
+                }
+                term_id
+              }
+              aggregate {
+                count
+              }
+            }
+          }
+        }
+        aggregate {
+          count
+        }
+      }
+    }
+    object {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    predicate {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+    counter_term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+  }
+  userTriplesAggregate: triples_aggregate(where: $userWhere) {
+    aggregate {
+      count
+    }
+  }
+  userTriples: triples(where: $userWhere) {
+    term_id
+    counter_term_id
+    subject {
+      term_id
+      label
+      wallet_id
+      image
+      type
+      tags: as_subject_triples_aggregate(
+        where: {predicate_id: {_eq: $tagPredicateId}}
+      ) {
+        nodes {
+          object {
+            label
+            term_id
+            taggedIdentities: as_object_triples_aggregate {
+              nodes {
+                subject {
+                  label
+                  term_id
+                }
+                term_id
+              }
+              aggregate {
+                count
+              }
+            }
+          }
+        }
+        aggregate {
+          count
+        }
+      }
+    }
+    object {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    predicate {
+      term_id
+      label
+      wallet_id
+      image
+      type
+    }
+    term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+    counter_term {
+      vaults {
+        current_share_price
+        position_count
+        total_shares
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        account {
+          id
+          label
+          image
+        }
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetListDetailsWithUserQuery = <
+  TData = GetListDetailsWithUserQuery,
+  TError = unknown
+>(
+  variables?: GetListDetailsWithUserQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetListDetailsWithUserQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetListDetailsWithUserQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetListDetailsWithUserQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetListDetailsWithUser"]
+        : ["GetListDetailsWithUser", variables],
+    queryFn: fetcher<
+      GetListDetailsWithUserQuery,
+      GetListDetailsWithUserQueryVariables
+    >(GetListDetailsWithUserDocument, variables),
+    ...options
+  })
+}
+
+useGetListDetailsWithUserQuery.document = GetListDetailsWithUserDocument
+
+useGetListDetailsWithUserQuery.getKey = (
+  variables?: GetListDetailsWithUserQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListDetailsWithUser"]
+    : ["GetListDetailsWithUser", variables]
+
+export const useInfiniteGetListDetailsWithUserQuery = <
+  TData = InfiniteData<GetListDetailsWithUserQuery>,
+  TError = unknown
+>(
+  variables: GetListDetailsWithUserQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListDetailsWithUserQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetListDetailsWithUserQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListDetailsWithUserQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetListDetailsWithUser.infinite"]
+            : ["GetListDetailsWithUser.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetListDetailsWithUserQuery,
+            GetListDetailsWithUserQueryVariables
+          >(GetListDetailsWithUserDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListDetailsWithUserQuery.getKey = (
+  variables?: GetListDetailsWithUserQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListDetailsWithUser.infinite"]
+    : ["GetListDetailsWithUser.infinite", variables]
+
+useGetListDetailsWithUserQuery.fetcher = (
+  variables?: GetListDetailsWithUserQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetListDetailsWithUserQuery, GetListDetailsWithUserQueryVariables>(
+    GetListDetailsWithUserDocument,
+    variables,
+    options
+  )
+
+export const GetFeeTransfersDocument = `
+    query GetFeeTransfers($address: String!, $cutoff_timestamp: bigint) {
+  before_cutoff: fee_transfers_aggregate(
+    where: {block_timestamp: {_lte: $cutoff_timestamp}, sender_id: {_eq: $address}}
+  ) {
+    aggregate {
+      sum {
+        amount
+      }
+    }
+  }
+  after_cutoff: fee_transfers_aggregate(
+    where: {block_timestamp: {_gt: $cutoff_timestamp}, sender_id: {_eq: $address}}
+  ) {
+    aggregate {
+      sum {
+        amount
+      }
+    }
+  }
+}
+    `
+
+export const useGetFeeTransfersQuery = <
+  TData = GetFeeTransfersQuery,
+  TError = unknown
+>(
+  variables: GetFeeTransfersQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetFeeTransfersQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetFeeTransfersQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetFeeTransfersQuery, TError, TData>({
+    queryKey: ["GetFeeTransfers", variables],
+    queryFn: fetcher<GetFeeTransfersQuery, GetFeeTransfersQueryVariables>(
+      GetFeeTransfersDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetFeeTransfersQuery.document = GetFeeTransfersDocument
+
+useGetFeeTransfersQuery.getKey = (variables: GetFeeTransfersQueryVariables) => [
+  "GetFeeTransfers",
+  variables
+]
+
+export const useInfiniteGetFeeTransfersQuery = <
+  TData = InfiniteData<GetFeeTransfersQuery>,
+  TError = unknown
+>(
+  variables: GetFeeTransfersQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetFeeTransfersQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetFeeTransfersQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetFeeTransfersQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetFeeTransfers.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetFeeTransfersQuery, GetFeeTransfersQueryVariables>(
+            GetFeeTransfersDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetFeeTransfersQuery.getKey = (
+  variables: GetFeeTransfersQueryVariables
+) => ["GetFeeTransfers.infinite", variables]
+
+useGetFeeTransfersQuery.fetcher = (
+  variables: GetFeeTransfersQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetFeeTransfersQuery, GetFeeTransfersQueryVariables>(
+    GetFeeTransfersDocument,
+    variables,
+    options
+  )
+
+export const GetPositionsDocument = `
+    query GetPositions($limit: Int, $offset: Int, $orderBy: [positions_order_by!], $where: positions_bool_exp) {
+  total: positions_aggregate(where: $where) {
+    aggregate {
+      count
+      sum {
+        shares
+      }
+    }
+  }
+  positions(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...PositionDetails
+  }
+}
+    ${PositionDetailsFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetPositionsQuery = <
+  TData = GetPositionsQuery,
+  TError = unknown
+>(
+  variables?: GetPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetPositionsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetPositions"] : ["GetPositions", variables],
+    queryFn: fetcher<GetPositionsQuery, GetPositionsQueryVariables>(
+      GetPositionsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetPositionsQuery.document = GetPositionsDocument
+
+useGetPositionsQuery.getKey = (variables?: GetPositionsQueryVariables) =>
+  variables === undefined ? ["GetPositions"] : ["GetPositions", variables]
+
+export const useInfiniteGetPositionsQuery = <
+  TData = InfiniteData<GetPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetPositions.infinite"]
+            : ["GetPositions.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetPositionsQuery, GetPositionsQueryVariables>(
+            GetPositionsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetPositionsQuery.getKey = (
+  variables?: GetPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositions.infinite"]
+    : ["GetPositions.infinite", variables]
+
+useGetPositionsQuery.fetcher = (
+  variables?: GetPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetPositionsQuery, GetPositionsQueryVariables>(
+    GetPositionsDocument,
+    variables,
+    options
+  )
+
+export const GetTriplePositionsByAddressDocument = `
+    query GetTriplePositionsByAddress($limit: Int, $offset: Int, $orderBy: [positions_order_by!], $where: positions_bool_exp, $address: String!) {
+  total: positions_aggregate(where: $where) {
+    aggregate {
+      count
+      sum {
+        shares
+      }
+    }
+  }
+  positions(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...PositionDetails
+    vault {
+      term_id
+      term {
+        triple {
+          term {
+            positions(where: {account_id: {_eq: $address}}) {
+              account {
+                id
+                label
+                image
+              }
+              shares
+            }
+          }
+          counter_term {
+            positions(where: {account_id: {_eq: $address}}) {
+              account {
+                id
+                label
+                image
+              }
+              shares
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    ${PositionDetailsFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetTriplePositionsByAddressQuery = <
+  TData = GetTriplePositionsByAddressQuery,
+  TError = unknown
+>(
+  variables: GetTriplePositionsByAddressQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplePositionsByAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetTriplePositionsByAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetTriplePositionsByAddressQuery, TError, TData>({
+    queryKey: ["GetTriplePositionsByAddress", variables],
+    queryFn: fetcher<
+      GetTriplePositionsByAddressQuery,
+      GetTriplePositionsByAddressQueryVariables
+    >(GetTriplePositionsByAddressDocument, variables),
+    ...options
+  })
+}
+
+useGetTriplePositionsByAddressQuery.document =
+  GetTriplePositionsByAddressDocument
+
+useGetTriplePositionsByAddressQuery.getKey = (
+  variables: GetTriplePositionsByAddressQueryVariables
+) => ["GetTriplePositionsByAddress", variables]
+
+export const useInfiniteGetTriplePositionsByAddressQuery = <
+  TData = InfiniteData<GetTriplePositionsByAddressQuery>,
+  TError = unknown
+>(
+  variables: GetTriplePositionsByAddressQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplePositionsByAddressQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplePositionsByAddressQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTriplePositionsByAddressQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? [
+          "GetTriplePositionsByAddress.infinite",
+          variables
+        ],
+        queryFn: (metaData) =>
+          fetcher<
+            GetTriplePositionsByAddressQuery,
+            GetTriplePositionsByAddressQueryVariables
+          >(GetTriplePositionsByAddressDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTriplePositionsByAddressQuery.getKey = (
+  variables: GetTriplePositionsByAddressQueryVariables
+) => ["GetTriplePositionsByAddress.infinite", variables]
+
+useGetTriplePositionsByAddressQuery.fetcher = (
+  variables: GetTriplePositionsByAddressQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetTriplePositionsByAddressQuery,
+    GetTriplePositionsByAddressQueryVariables
+  >(GetTriplePositionsByAddressDocument, variables, options)
+
+export const GetPositionsWithAggregatesDocument = `
+    query GetPositionsWithAggregates($limit: Int, $offset: Int, $orderBy: [positions_order_by!], $where: positions_bool_exp) {
+  positions_aggregate(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+    where: $where
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      ...PositionDetails
+    }
+  }
+}
+    ${PositionDetailsFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetPositionsWithAggregatesQuery = <
+  TData = GetPositionsWithAggregatesQuery,
+  TError = unknown
+>(
+  variables?: GetPositionsWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetPositionsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetPositionsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetPositionsWithAggregatesQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetPositionsWithAggregates"]
+        : ["GetPositionsWithAggregates", variables],
+    queryFn: fetcher<
+      GetPositionsWithAggregatesQuery,
+      GetPositionsWithAggregatesQueryVariables
+    >(GetPositionsWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetPositionsWithAggregatesQuery.document = GetPositionsWithAggregatesDocument
+
+useGetPositionsWithAggregatesQuery.getKey = (
+  variables?: GetPositionsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsWithAggregates"]
+    : ["GetPositionsWithAggregates", variables]
+
+export const useInfiniteGetPositionsWithAggregatesQuery = <
+  TData = InfiniteData<GetPositionsWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetPositionsWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetPositionsWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetPositionsWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetPositionsWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetPositionsWithAggregates.infinite"]
+            : ["GetPositionsWithAggregates.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetPositionsWithAggregatesQuery,
+            GetPositionsWithAggregatesQueryVariables
+          >(GetPositionsWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetPositionsWithAggregatesQuery.getKey = (
+  variables?: GetPositionsWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsWithAggregates.infinite"]
+    : ["GetPositionsWithAggregates.infinite", variables]
+
+useGetPositionsWithAggregatesQuery.fetcher = (
+  variables?: GetPositionsWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetPositionsWithAggregatesQuery,
+    GetPositionsWithAggregatesQueryVariables
+  >(GetPositionsWithAggregatesDocument, variables, options)
+
+export const GetPositionsCountDocument = `
+    query GetPositionsCount($where: positions_bool_exp) {
+  positions_aggregate(where: $where) {
+    total: aggregate {
+      count
+      sum {
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetPositionsCountQuery = <
+  TData = GetPositionsCountQuery,
+  TError = unknown
+>(
+  variables?: GetPositionsCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetPositionsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetPositionsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetPositionsCountQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetPositionsCount"]
+        : ["GetPositionsCount", variables],
+    queryFn: fetcher<GetPositionsCountQuery, GetPositionsCountQueryVariables>(
+      GetPositionsCountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetPositionsCountQuery.document = GetPositionsCountDocument
+
+useGetPositionsCountQuery.getKey = (
+  variables?: GetPositionsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsCount"]
+    : ["GetPositionsCount", variables]
+
+export const useInfiniteGetPositionsCountQuery = <
+  TData = InfiniteData<GetPositionsCountQuery>,
+  TError = unknown
+>(
+  variables: GetPositionsCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetPositionsCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetPositionsCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetPositionsCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetPositionsCount.infinite"]
+            : ["GetPositionsCount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetPositionsCountQuery, GetPositionsCountQueryVariables>(
+            GetPositionsCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetPositionsCountQuery.getKey = (
+  variables?: GetPositionsCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsCount.infinite"]
+    : ["GetPositionsCount.infinite", variables]
+
+useGetPositionsCountQuery.fetcher = (
+  variables?: GetPositionsCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetPositionsCountQuery, GetPositionsCountQueryVariables>(
+    GetPositionsCountDocument,
+    variables,
+    options
+  )
+
+export const GetPositionDocument = `
+    query GetPosition($positionId: String!) {
+  position(id: $positionId) {
+    ...PositionDetails
+  }
+}
+    ${PositionDetailsFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetPositionQuery = <TData = GetPositionQuery, TError = unknown>(
+  variables: GetPositionQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetPositionQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetPositionQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetPositionQuery, TError, TData>({
+    queryKey: ["GetPosition", variables],
+    queryFn: fetcher<GetPositionQuery, GetPositionQueryVariables>(
+      GetPositionDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetPositionQuery.document = GetPositionDocument
+
+useGetPositionQuery.getKey = (variables: GetPositionQueryVariables) => [
+  "GetPosition",
+  variables
+]
+
+export const useInfiniteGetPositionQuery = <
+  TData = InfiniteData<GetPositionQuery>,
+  TError = unknown
+>(
+  variables: GetPositionQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetPositionQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetPositionQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetPositionQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetPosition.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetPositionQuery, GetPositionQueryVariables>(
+            GetPositionDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetPositionQuery.getKey = (variables: GetPositionQueryVariables) => [
+  "GetPosition.infinite",
+  variables
+]
+
+useGetPositionQuery.fetcher = (
+  variables: GetPositionQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetPositionQuery, GetPositionQueryVariables>(
+    GetPositionDocument,
+    variables,
+    options
+  )
+
+export const GetPositionsCountByTypeDocument = `
+    query GetPositionsCountByType($where: positions_bool_exp) {
+  positions_aggregate(where: $where) {
+    total: aggregate {
+      count
+      sum {
+        shares
+      }
+    }
+  }
+  positions {
+    vault {
+      term_id
+    }
+  }
+}
+    `
+
+export const useGetPositionsCountByTypeQuery = <
+  TData = GetPositionsCountByTypeQuery,
+  TError = unknown
+>(
+  variables?: GetPositionsCountByTypeQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetPositionsCountByTypeQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetPositionsCountByTypeQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetPositionsCountByTypeQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetPositionsCountByType"]
+        : ["GetPositionsCountByType", variables],
+    queryFn: fetcher<
+      GetPositionsCountByTypeQuery,
+      GetPositionsCountByTypeQueryVariables
+    >(GetPositionsCountByTypeDocument, variables),
+    ...options
+  })
+}
+
+useGetPositionsCountByTypeQuery.document = GetPositionsCountByTypeDocument
+
+useGetPositionsCountByTypeQuery.getKey = (
+  variables?: GetPositionsCountByTypeQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsCountByType"]
+    : ["GetPositionsCountByType", variables]
+
+export const useInfiniteGetPositionsCountByTypeQuery = <
+  TData = InfiniteData<GetPositionsCountByTypeQuery>,
+  TError = unknown
+>(
+  variables: GetPositionsCountByTypeQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetPositionsCountByTypeQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetPositionsCountByTypeQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetPositionsCountByTypeQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetPositionsCountByType.infinite"]
+            : ["GetPositionsCountByType.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetPositionsCountByTypeQuery,
+            GetPositionsCountByTypeQueryVariables
+          >(GetPositionsCountByTypeDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetPositionsCountByTypeQuery.getKey = (
+  variables?: GetPositionsCountByTypeQueryVariables
+) =>
+  variables === undefined
+    ? ["GetPositionsCountByType.infinite"]
+    : ["GetPositionsCountByType.infinite", variables]
+
+useGetPositionsCountByTypeQuery.fetcher = (
+  variables?: GetPositionsCountByTypeQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetPositionsCountByTypeQuery, GetPositionsCountByTypeQueryVariables>(
+    GetPositionsCountByTypeDocument,
+    variables,
+    options
+  )
+
+export const GetSignalsDocument = `
+    query GetSignals($limit: Int, $offset: Int, $orderBy: [signals_order_by!], $addresses: [String!]) {
+  total: events_aggregate {
+    aggregate {
+      count
+    }
+  }
+  signals(limit: $limit, offset: $offset, order_by: $orderBy) {
+    id
+    block_number
+    block_timestamp
+    transaction_hash
+    atom_id
+    triple_id
+    deposit_id
+    redemption_id
+    term {
+      atom {
+        ...AtomMetadata
+        term {
+          vaults {
+            total_shares
+            position_count
+            positions(where: {account: {id: {_in: $addresses}}}) {
+              account_id
+              shares
+              account {
+                id
+                label
+                image
+              }
+            }
+          }
+        }
+      }
+      triple {
+        term_id
+        creator {
+          ...AccountMetadata
+        }
+        subject {
+          data
+          term_id
+          image
+          label
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+        predicate {
+          data
+          term_id
+          image
+          label
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+        object {
+          data
+          term_id
+          image
+          label
+          emoji
+          type
+          ...AtomValue
+          creator {
+            ...AccountMetadata
+          }
+        }
+        term {
+          vaults {
+            total_shares
+            position_count
+            positions(where: {account: {id: {_in: $addresses}}}) {
+              account_id
+              shares
+              account {
+                id
+                label
+                image
+              }
+            }
+          }
+        }
+        counter_term {
+          vaults {
+            total_shares
+            position_count
+            positions(where: {account: {id: {_in: $addresses}}}) {
+              account_id
+              shares
+              account {
+                id
+                label
+                image
+              }
+            }
+          }
+        }
+      }
+    }
+    deposit {
+      sender_id
+      sender {
+        id
+        label
+        image
+      }
+      receiver_id
+      receiver {
+        id
+        label
+        image
+      }
+      shares_for_receiver
+      sender_assets_after_total_fees
+      vault {
+        total_shares
+        position_count
+        positions(where: {account: {id: {_in: $addresses}}}) {
+          account_id
+          shares
+          account {
+            id
+            label
+            image
+          }
+        }
+      }
+    }
+    redemption {
+      sender_id
+      sender {
+        id
+        label
+        image
+      }
+      receiver_id
+      receiver {
+        id
+        label
+        image
+      }
+      assets_for_receiver
+      shares_redeemed_by_sender
+    }
+  }
+}
+    ${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}`
+
+export const useGetSignalsQuery = <TData = GetSignalsQuery, TError = unknown>(
+  variables?: GetSignalsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetSignalsQuery, TError, TData>,
+    "queryKey"
+  > & { queryKey?: UseQueryOptions<GetSignalsQuery, TError, TData>["queryKey"] }
+) => {
+  return useQuery<GetSignalsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetSignals"] : ["GetSignals", variables],
+    queryFn: fetcher<GetSignalsQuery, GetSignalsQueryVariables>(
+      GetSignalsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetSignalsQuery.document = GetSignalsDocument
+
+useGetSignalsQuery.getKey = (variables?: GetSignalsQueryVariables) =>
+  variables === undefined ? ["GetSignals"] : ["GetSignals", variables]
+
+export const useInfiniteGetSignalsQuery = <
+  TData = InfiniteData<GetSignalsQuery>,
+  TError = unknown
+>(
+  variables: GetSignalsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetSignalsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetSignalsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetSignalsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetSignals.infinite"]
+            : ["GetSignals.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetSignalsQuery, GetSignalsQueryVariables>(
+            GetSignalsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetSignalsQuery.getKey = (variables?: GetSignalsQueryVariables) =>
+  variables === undefined
+    ? ["GetSignals.infinite"]
+    : ["GetSignals.infinite", variables]
+
+useGetSignalsQuery.fetcher = (
+  variables?: GetSignalsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetSignalsQuery, GetSignalsQueryVariables>(
+    GetSignalsDocument,
+    variables,
+    options
+  )
+
+export const GetStatsDocument = `
+    query GetStats {
+  stats {
+    ...StatDetails
+  }
+}
+    ${StatDetailsFragmentDoc}`
+
+export const useGetStatsQuery = <TData = GetStatsQuery, TError = unknown>(
+  variables?: GetStatsQueryVariables,
+  options?: Omit<UseQueryOptions<GetStatsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetStatsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetStatsQuery, TError, TData>({
+    queryKey: variables === undefined ? ["GetStats"] : ["GetStats", variables],
+    queryFn: fetcher<GetStatsQuery, GetStatsQueryVariables>(
+      GetStatsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetStatsQuery.document = GetStatsDocument
+
+useGetStatsQuery.getKey = (variables?: GetStatsQueryVariables) =>
+  variables === undefined ? ["GetStats"] : ["GetStats", variables]
+
+export const useInfiniteGetStatsQuery = <
+  TData = InfiniteData<GetStatsQuery>,
+  TError = unknown
+>(
+  variables: GetStatsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetStatsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetStatsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetStatsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetStats.infinite"]
+            : ["GetStats.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetStatsQuery, GetStatsQueryVariables>(GetStatsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetStatsQuery.getKey = (variables?: GetStatsQueryVariables) =>
+  variables === undefined
+    ? ["GetStats.infinite"]
+    : ["GetStats.infinite", variables]
+
+useGetStatsQuery.fetcher = (
+  variables?: GetStatsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetStatsQuery, GetStatsQueryVariables>(
+    GetStatsDocument,
+    variables,
+    options
+  )
+
+export const GetTagsDocument = `
+    query GetTags($subjectId: numeric!, $predicateId: numeric!) {
+  triples(
+    where: {_and: [{subject_id: {_eq: $subjectId}}, {predicate_id: {_eq: $predicateId}}]}
+  ) {
+    ...TripleMetadata
+  }
+}
+    ${TripleMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}`
+
+export const useGetTagsQuery = <TData = GetTagsQuery, TError = unknown>(
+  variables: GetTagsQueryVariables,
+  options?: Omit<UseQueryOptions<GetTagsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetTagsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetTagsQuery, TError, TData>({
+    queryKey: ["GetTags", variables],
+    queryFn: fetcher<GetTagsQuery, GetTagsQueryVariables>(
+      GetTagsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTagsQuery.document = GetTagsDocument
+
+useGetTagsQuery.getKey = (variables: GetTagsQueryVariables) => [
+  "GetTags",
+  variables
+]
+
+export const useInfiniteGetTagsQuery = <
+  TData = InfiniteData<GetTagsQuery>,
+  TError = unknown
+>(
+  variables: GetTagsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTagsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetTagsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTagsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetTags.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTagsQuery, GetTagsQueryVariables>(GetTagsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTagsQuery.getKey = (variables: GetTagsQueryVariables) => [
+  "GetTags.infinite",
+  variables
+]
+
+useGetTagsQuery.fetcher = (
+  variables: GetTagsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTagsQuery, GetTagsQueryVariables>(
+    GetTagsDocument,
+    variables,
+    options
+  )
+
+export const GetTagsCustomDocument = `
+    query GetTagsCustom($where: triples_bool_exp) {
+  triples(where: $where) {
+    ...TripleMetadata
+  }
+}
+    ${TripleMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}`
+
+export const useGetTagsCustomQuery = <
+  TData = GetTagsCustomQuery,
+  TError = unknown
+>(
+  variables?: GetTagsCustomQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTagsCustomQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetTagsCustomQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetTagsCustomQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetTagsCustom"]
+        : ["GetTagsCustom", variables],
+    queryFn: fetcher<GetTagsCustomQuery, GetTagsCustomQueryVariables>(
+      GetTagsCustomDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTagsCustomQuery.document = GetTagsCustomDocument
+
+useGetTagsCustomQuery.getKey = (variables?: GetTagsCustomQueryVariables) =>
+  variables === undefined ? ["GetTagsCustom"] : ["GetTagsCustom", variables]
+
+export const useInfiniteGetTagsCustomQuery = <
+  TData = InfiniteData<GetTagsCustomQuery>,
+  TError = unknown
+>(
+  variables: GetTagsCustomQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTagsCustomQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTagsCustomQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTagsCustomQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetTagsCustom.infinite"]
+            : ["GetTagsCustom.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTagsCustomQuery, GetTagsCustomQueryVariables>(
+            GetTagsCustomDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTagsCustomQuery.getKey = (
+  variables?: GetTagsCustomQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTagsCustom.infinite"]
+    : ["GetTagsCustom.infinite", variables]
+
+useGetTagsCustomQuery.fetcher = (
+  variables?: GetTagsCustomQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTagsCustomQuery, GetTagsCustomQueryVariables>(
+    GetTagsCustomDocument,
+    variables,
+    options
+  )
+
+export const GetListsTagsDocument = `
+    query GetListsTags($where: atoms_bool_exp, $triplesWhere: triples_bool_exp, $limit: Int, $offset: Int, $orderBy: [atoms_order_by!]) {
+  atoms_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  atoms(where: $where, limit: $limit, offset: $offset, order_by: $orderBy) {
+    term_id
+    label
+    image
+    value {
+      thing {
+        description
+      }
+    }
+    as_object_triples_aggregate(where: $triplesWhere) {
+      aggregate {
+        count
+      }
+    }
+    as_object_triples(
+      where: $triplesWhere
+      limit: 10
+      order_by: {term: {total_market_cap: desc}}
+    ) {
+      subject {
+        label
+        image
+      }
+    }
+  }
+}
+    `
+
+export const useGetListsTagsQuery = <
+  TData = GetListsTagsQuery,
+  TError = unknown
+>(
+  variables?: GetListsTagsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetListsTagsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetListsTagsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetListsTagsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetListsTags"] : ["GetListsTags", variables],
+    queryFn: fetcher<GetListsTagsQuery, GetListsTagsQueryVariables>(
+      GetListsTagsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetListsTagsQuery.document = GetListsTagsDocument
+
+useGetListsTagsQuery.getKey = (variables?: GetListsTagsQueryVariables) =>
+  variables === undefined ? ["GetListsTags"] : ["GetListsTags", variables]
+
+export const useInfiniteGetListsTagsQuery = <
+  TData = InfiniteData<GetListsTagsQuery>,
+  TError = unknown
+>(
+  variables: GetListsTagsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetListsTagsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetListsTagsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetListsTagsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetListsTags.infinite"]
+            : ["GetListsTags.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetListsTagsQuery, GetListsTagsQueryVariables>(
+            GetListsTagsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetListsTagsQuery.getKey = (
+  variables?: GetListsTagsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetListsTags.infinite"]
+    : ["GetListsTags.infinite", variables]
+
+useGetListsTagsQuery.fetcher = (
+  variables?: GetListsTagsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetListsTagsQuery, GetListsTagsQueryVariables>(
+    GetListsTagsDocument,
+    variables,
+    options
+  )
+
+export const GetTaggedObjectsDocument = `
+    query GetTaggedObjects($objectId: numeric!, $predicateId: numeric!, $address: String) {
+  triples(where: {object_id: {_eq: $objectId}, predicate_id: {_eq: $predicateId}}) {
+    term_id
+    subject {
+      term_id
+      label
+      image
+      value {
+        thing {
+          name
+          description
+          url
+        }
+        person {
+          description
+        }
+      }
+      term {
+        vaults {
+          position_count
+        }
+      }
+    }
+    term {
+      id
+      vaults {
+        position_count
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        shares
+      }
+    }
+    counter_term {
+      id
+      vaults {
+        position_count
+      }
+      positions(where: {account_id: {_eq: $address}}) {
+        shares
+      }
+    }
+  }
+}
+    `
+
+export const useGetTaggedObjectsQuery = <
+  TData = GetTaggedObjectsQuery,
+  TError = unknown
+>(
+  variables: GetTaggedObjectsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTaggedObjectsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetTaggedObjectsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetTaggedObjectsQuery, TError, TData>({
+    queryKey: ["GetTaggedObjects", variables],
+    queryFn: fetcher<GetTaggedObjectsQuery, GetTaggedObjectsQueryVariables>(
+      GetTaggedObjectsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTaggedObjectsQuery.document = GetTaggedObjectsDocument
+
+useGetTaggedObjectsQuery.getKey = (
+  variables: GetTaggedObjectsQueryVariables
+) => ["GetTaggedObjects", variables]
+
+export const useInfiniteGetTaggedObjectsQuery = <
+  TData = InfiniteData<GetTaggedObjectsQuery>,
+  TError = unknown
+>(
+  variables: GetTaggedObjectsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTaggedObjectsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTaggedObjectsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTaggedObjectsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetTaggedObjects.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTaggedObjectsQuery, GetTaggedObjectsQueryVariables>(
+            GetTaggedObjectsDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTaggedObjectsQuery.getKey = (
+  variables: GetTaggedObjectsQueryVariables
+) => ["GetTaggedObjects.infinite", variables]
+
+useGetTaggedObjectsQuery.fetcher = (
+  variables: GetTaggedObjectsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTaggedObjectsQuery, GetTaggedObjectsQueryVariables>(
+    GetTaggedObjectsDocument,
+    variables,
+    options
+  )
+
+export const GetTriplesDocument = `
+    query GetTriples($limit: Int, $offset: Int, $orderBy: [triples_order_by!], $where: triples_bool_exp) {
+  total: triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    ...TripleMetadata
+    ...TripleTxn
+    ...TripleVaultDetails
+    creator {
+      ...AccountMetadata
+    }
+  }
+}
+    ${TripleMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}
+${TripleTxnFragmentDoc}
+${TripleVaultDetailsFragmentDoc}
+${PositionDetailsFragmentDoc}`
+
+export const useGetTriplesQuery = <TData = GetTriplesQuery, TError = unknown>(
+  variables?: GetTriplesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplesQuery, TError, TData>,
+    "queryKey"
+  > & { queryKey?: UseQueryOptions<GetTriplesQuery, TError, TData>["queryKey"] }
+) => {
+  return useQuery<GetTriplesQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetTriples"] : ["GetTriples", variables],
+    queryFn: fetcher<GetTriplesQuery, GetTriplesQueryVariables>(
+      GetTriplesDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTriplesQuery.document = GetTriplesDocument
+
+useGetTriplesQuery.getKey = (variables?: GetTriplesQueryVariables) =>
+  variables === undefined ? ["GetTriples"] : ["GetTriples", variables]
+
+export const useInfiniteGetTriplesQuery = <
+  TData = InfiniteData<GetTriplesQuery>,
+  TError = unknown
+>(
+  variables: GetTriplesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTriplesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetTriples.infinite"]
+            : ["GetTriples.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTriplesQuery, GetTriplesQueryVariables>(
+            GetTriplesDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTriplesQuery.getKey = (variables?: GetTriplesQueryVariables) =>
+  variables === undefined
+    ? ["GetTriples.infinite"]
+    : ["GetTriples.infinite", variables]
+
+useGetTriplesQuery.fetcher = (
+  variables?: GetTriplesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTriplesQuery, GetTriplesQueryVariables>(
+    GetTriplesDocument,
+    variables,
+    options
+  )
+
+export const GetTriplesWithAggregatesDocument = `
+    query GetTriplesWithAggregates($limit: Int, $offset: Int, $orderBy: [triples_order_by!], $where: triples_bool_exp) {
+  triples_aggregate(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+    where: $where
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      ...TripleMetadata
+      ...TripleTxn
+      ...TripleVaultDetails
+      creator {
+        ...AccountMetadata
+      }
+    }
+  }
+}
+    ${TripleMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}
+${TripleTxnFragmentDoc}
+${TripleVaultDetailsFragmentDoc}
+${PositionDetailsFragmentDoc}`
+
+export const useGetTriplesWithAggregatesQuery = <
+  TData = GetTriplesWithAggregatesQuery,
+  TError = unknown
+>(
+  variables?: GetTriplesWithAggregatesQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplesWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetTriplesWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetTriplesWithAggregatesQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetTriplesWithAggregates"]
+        : ["GetTriplesWithAggregates", variables],
+    queryFn: fetcher<
+      GetTriplesWithAggregatesQuery,
+      GetTriplesWithAggregatesQueryVariables
+    >(GetTriplesWithAggregatesDocument, variables),
+    ...options
+  })
+}
+
+useGetTriplesWithAggregatesQuery.document = GetTriplesWithAggregatesDocument
+
+useGetTriplesWithAggregatesQuery.getKey = (
+  variables?: GetTriplesWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTriplesWithAggregates"]
+    : ["GetTriplesWithAggregates", variables]
+
+export const useInfiniteGetTriplesWithAggregatesQuery = <
+  TData = InfiniteData<GetTriplesWithAggregatesQuery>,
+  TError = unknown
+>(
+  variables: GetTriplesWithAggregatesQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplesWithAggregatesQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplesWithAggregatesQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTriplesWithAggregatesQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetTriplesWithAggregates.infinite"]
+            : ["GetTriplesWithAggregates.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetTriplesWithAggregatesQuery,
+            GetTriplesWithAggregatesQueryVariables
+          >(GetTriplesWithAggregatesDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTriplesWithAggregatesQuery.getKey = (
+  variables?: GetTriplesWithAggregatesQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTriplesWithAggregates.infinite"]
+    : ["GetTriplesWithAggregates.infinite", variables]
+
+useGetTriplesWithAggregatesQuery.fetcher = (
+  variables?: GetTriplesWithAggregatesQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetTriplesWithAggregatesQuery,
+    GetTriplesWithAggregatesQueryVariables
+  >(GetTriplesWithAggregatesDocument, variables, options)
+
+export const GetTriplesCountDocument = `
+    query GetTriplesCount($where: triples_bool_exp) {
+  triples_aggregate(where: $where) {
+    total: aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetTriplesCountQuery = <
+  TData = GetTriplesCountQuery,
+  TError = unknown
+>(
+  variables?: GetTriplesCountQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplesCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<GetTriplesCountQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetTriplesCountQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetTriplesCount"]
+        : ["GetTriplesCount", variables],
+    queryFn: fetcher<GetTriplesCountQuery, GetTriplesCountQueryVariables>(
+      GetTriplesCountDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTriplesCountQuery.document = GetTriplesCountDocument
+
+useGetTriplesCountQuery.getKey = (variables?: GetTriplesCountQueryVariables) =>
+  variables === undefined ? ["GetTriplesCount"] : ["GetTriplesCount", variables]
+
+export const useInfiniteGetTriplesCountQuery = <
+  TData = InfiniteData<GetTriplesCountQuery>,
+  TError = unknown
+>(
+  variables: GetTriplesCountQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplesCountQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplesCountQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTriplesCountQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetTriplesCount.infinite"]
+            : ["GetTriplesCount.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTriplesCountQuery, GetTriplesCountQueryVariables>(
+            GetTriplesCountDocument,
+            { ...variables, ...(metaData.pageParam ?? {}) }
+          )(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTriplesCountQuery.getKey = (
+  variables?: GetTriplesCountQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTriplesCount.infinite"]
+    : ["GetTriplesCount.infinite", variables]
+
+useGetTriplesCountQuery.fetcher = (
+  variables?: GetTriplesCountQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTriplesCountQuery, GetTriplesCountQueryVariables>(
+    GetTriplesCountDocument,
+    variables,
+    options
+  )
+
+export const GetTripleDocument = `
+    query GetTriple($tripleId: numeric!) {
+  triple(term_id: $tripleId) {
+    ...TripleMetadata
+    ...TripleTxn
+    ...TripleVaultDetails
+    creator {
+      ...AccountMetadata
+    }
+  }
+}
+    ${TripleMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${AccountMetadataFragmentDoc}
+${PositionAggregateFieldsFragmentDoc}
+${PositionFieldsFragmentDoc}
+${TripleTxnFragmentDoc}
+${TripleVaultDetailsFragmentDoc}
+${PositionDetailsFragmentDoc}`
+
+export const useGetTripleQuery = <TData = GetTripleQuery, TError = unknown>(
+  variables: GetTripleQueryVariables,
+  options?: Omit<UseQueryOptions<GetTripleQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetTripleQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetTripleQuery, TError, TData>({
+    queryKey: ["GetTriple", variables],
+    queryFn: fetcher<GetTripleQuery, GetTripleQueryVariables>(
+      GetTripleDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetTripleQuery.document = GetTripleDocument
+
+useGetTripleQuery.getKey = (variables: GetTripleQueryVariables) => [
+  "GetTriple",
+  variables
+]
+
+export const useInfiniteGetTripleQuery = <
+  TData = InfiniteData<GetTripleQuery>,
+  TError = unknown
+>(
+  variables: GetTripleQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTripleQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTripleQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTripleQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetTriple.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetTripleQuery, GetTripleQueryVariables>(GetTripleDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTripleQuery.getKey = (variables: GetTripleQueryVariables) => [
+  "GetTriple.infinite",
+  variables
+]
+
+useGetTripleQuery.fetcher = (
+  variables: GetTripleQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTripleQuery, GetTripleQueryVariables>(
+    GetTripleDocument,
+    variables,
+    options
+  )
+
+export const GetAtomTriplesWithPositionsDocument = `
+    query GetAtomTriplesWithPositions($where: triples_bool_exp) {
+  triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+}
+    `
+
+export const useGetAtomTriplesWithPositionsQuery = <
+  TData = GetAtomTriplesWithPositionsQuery,
+  TError = unknown
+>(
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetAtomTriplesWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetAtomTriplesWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetAtomTriplesWithPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetAtomTriplesWithPositions"]
+        : ["GetAtomTriplesWithPositions", variables],
+    queryFn: fetcher<
+      GetAtomTriplesWithPositionsQuery,
+      GetAtomTriplesWithPositionsQueryVariables
+    >(GetAtomTriplesWithPositionsDocument, variables),
+    ...options
+  })
+}
+
+useGetAtomTriplesWithPositionsQuery.document =
+  GetAtomTriplesWithPositionsDocument
+
+useGetAtomTriplesWithPositionsQuery.getKey = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomTriplesWithPositions"]
+    : ["GetAtomTriplesWithPositions", variables]
+
+export const useInfiniteGetAtomTriplesWithPositionsQuery = <
+  TData = InfiniteData<GetAtomTriplesWithPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetAtomTriplesWithPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetAtomTriplesWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetAtomTriplesWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetAtomTriplesWithPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetAtomTriplesWithPositions.infinite"]
+            : ["GetAtomTriplesWithPositions.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetAtomTriplesWithPositionsQuery,
+            GetAtomTriplesWithPositionsQueryVariables
+          >(GetAtomTriplesWithPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetAtomTriplesWithPositionsQuery.getKey = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetAtomTriplesWithPositions.infinite"]
+    : ["GetAtomTriplesWithPositions.infinite", variables]
+
+useGetAtomTriplesWithPositionsQuery.fetcher = (
+  variables?: GetAtomTriplesWithPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<
+    GetAtomTriplesWithPositionsQuery,
+    GetAtomTriplesWithPositionsQueryVariables
+  >(GetAtomTriplesWithPositionsDocument, variables, options)
+
+export const GetTriplesWithPositionsDocument = `
+    query GetTriplesWithPositions($limit: Int, $offset: Int, $orderBy: [triples_order_by!], $where: triples_bool_exp, $address: String) {
+  total: triples_aggregate(where: $where) {
+    aggregate {
+      count
+    }
+  }
+  triples(limit: $limit, offset: $offset, order_by: $orderBy, where: $where) {
+    term_id
+    counter_term_id
+    subject {
+      term_id
+      label
+      image
+    }
+    predicate {
+      term_id
+      label
+      image
+    }
+    object {
+      term_id
+      label
+      image
+    }
+    term {
+      vaults {
+        total_shares
+        position_count
+        positions(where: {account_id: {_eq: $address}}) {
+          account {
+            id
+            label
+            image
+          }
+          shares
+        }
+      }
+    }
+    counter_term {
+      vaults {
+        total_shares
+        position_count
+        positions(where: {account_id: {_eq: $address}}) {
+          account {
+            id
+            label
+            image
+          }
+          shares
+        }
+      }
+    }
+  }
+}
+    `
+
+export const useGetTriplesWithPositionsQuery = <
+  TData = GetTriplesWithPositionsQuery,
+  TError = unknown
+>(
+  variables?: GetTriplesWithPositionsQueryVariables,
+  options?: Omit<
+    UseQueryOptions<GetTriplesWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<
+      GetTriplesWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useQuery<GetTriplesWithPositionsQuery, TError, TData>({
+    queryKey:
+      variables === undefined
+        ? ["GetTriplesWithPositions"]
+        : ["GetTriplesWithPositions", variables],
+    queryFn: fetcher<
+      GetTriplesWithPositionsQuery,
+      GetTriplesWithPositionsQueryVariables
+    >(GetTriplesWithPositionsDocument, variables),
+    ...options
+  })
+}
+
+useGetTriplesWithPositionsQuery.document = GetTriplesWithPositionsDocument
+
+useGetTriplesWithPositionsQuery.getKey = (
+  variables?: GetTriplesWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTriplesWithPositions"]
+    : ["GetTriplesWithPositions", variables]
+
+export const useInfiniteGetTriplesWithPositionsQuery = <
+  TData = InfiniteData<GetTriplesWithPositionsQuery>,
+  TError = unknown
+>(
+  variables: GetTriplesWithPositionsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetTriplesWithPositionsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetTriplesWithPositionsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetTriplesWithPositionsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetTriplesWithPositions.infinite"]
+            : ["GetTriplesWithPositions.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<
+            GetTriplesWithPositionsQuery,
+            GetTriplesWithPositionsQueryVariables
+          >(GetTriplesWithPositionsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetTriplesWithPositionsQuery.getKey = (
+  variables?: GetTriplesWithPositionsQueryVariables
+) =>
+  variables === undefined
+    ? ["GetTriplesWithPositions.infinite"]
+    : ["GetTriplesWithPositions.infinite", variables]
+
+useGetTriplesWithPositionsQuery.fetcher = (
+  variables?: GetTriplesWithPositionsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetTriplesWithPositionsQuery, GetTriplesWithPositionsQueryVariables>(
+    GetTriplesWithPositionsDocument,
+    variables,
+    options
+  )
+
+export const GetVaultsDocument = `
+    query GetVaults($limit: Int, $offset: Int, $orderBy: [vaults_order_by!], $where: vaults_bool_exp) {
+  vaults_aggregate(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+    where: $where
+  ) {
+    aggregate {
+      count
+    }
+    nodes {
+      term_id
+      term {
+        atom {
+          term_id
+          label
+        }
+        triple {
+          term_id
+          subject {
+            term_id
+            label
+          }
+          predicate {
+            term_id
+            label
+          }
+          object {
+            term_id
+            label
+          }
+        }
+      }
+      positions_aggregate {
+        nodes {
+          account {
+            atom_id
+            label
+          }
+          shares
+        }
+      }
+      current_share_price
+      total_shares
+    }
+  }
+}
+    `
+
+export const useGetVaultsQuery = <TData = GetVaultsQuery, TError = unknown>(
+  variables?: GetVaultsQueryVariables,
+  options?: Omit<UseQueryOptions<GetVaultsQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetVaultsQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetVaultsQuery, TError, TData>({
+    queryKey:
+      variables === undefined ? ["GetVaults"] : ["GetVaults", variables],
+    queryFn: fetcher<GetVaultsQuery, GetVaultsQueryVariables>(
+      GetVaultsDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetVaultsQuery.document = GetVaultsDocument
+
+useGetVaultsQuery.getKey = (variables?: GetVaultsQueryVariables) =>
+  variables === undefined ? ["GetVaults"] : ["GetVaults", variables]
+
+export const useInfiniteGetVaultsQuery = <
+  TData = InfiniteData<GetVaultsQuery>,
+  TError = unknown
+>(
+  variables: GetVaultsQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetVaultsQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<
+      GetVaultsQuery,
+      TError,
+      TData
+    >["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetVaultsQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey:
+          optionsQueryKey ?? variables === undefined
+            ? ["GetVaults.infinite"]
+            : ["GetVaults.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetVaultsQuery, GetVaultsQueryVariables>(GetVaultsDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetVaultsQuery.getKey = (variables?: GetVaultsQueryVariables) =>
+  variables === undefined
+    ? ["GetVaults.infinite"]
+    : ["GetVaults.infinite", variables]
+
+useGetVaultsQuery.fetcher = (
+  variables?: GetVaultsQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetVaultsQuery, GetVaultsQueryVariables>(
+    GetVaultsDocument,
+    variables,
+    options
+  )
+
+export const GetVaultDocument = `
+    query GetVault($termId: numeric!, $curveId: numeric!) {
+  vault(term_id: $termId, curve_id: $curveId) {
+    ...VaultDetails
+  }
+}
+    ${VaultDetailsFragmentDoc}
+${VaultBasicDetailsFragmentDoc}`
+
+export const useGetVaultQuery = <TData = GetVaultQuery, TError = unknown>(
+  variables: GetVaultQueryVariables,
+  options?: Omit<UseQueryOptions<GetVaultQuery, TError, TData>, "queryKey"> & {
+    queryKey?: UseQueryOptions<GetVaultQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useQuery<GetVaultQuery, TError, TData>({
+    queryKey: ["GetVault", variables],
+    queryFn: fetcher<GetVaultQuery, GetVaultQueryVariables>(
+      GetVaultDocument,
+      variables
+    ),
+    ...options
+  })
+}
+
+useGetVaultQuery.document = GetVaultDocument
+
+useGetVaultQuery.getKey = (variables: GetVaultQueryVariables) => [
+  "GetVault",
+  variables
+]
+
+export const useInfiniteGetVaultQuery = <
+  TData = InfiniteData<GetVaultQuery>,
+  TError = unknown
+>(
+  variables: GetVaultQueryVariables,
+  options: Omit<
+    UseInfiniteQueryOptions<GetVaultQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseInfiniteQueryOptions<GetVaultQuery, TError, TData>["queryKey"]
+  }
+) => {
+  return useInfiniteQuery<GetVaultQuery, TError, TData>(
+    (() => {
+      const { queryKey: optionsQueryKey, ...restOptions } = options
+      return {
+        queryKey: optionsQueryKey ?? ["GetVault.infinite", variables],
+        queryFn: (metaData) =>
+          fetcher<GetVaultQuery, GetVaultQueryVariables>(GetVaultDocument, {
+            ...variables,
+            ...(metaData.pageParam ?? {})
+          })(),
+        ...restOptions
+      }
+    })()
+  )
+}
+
+useInfiniteGetVaultQuery.getKey = (variables: GetVaultQueryVariables) => [
+  "GetVault.infinite",
+  variables
+]
+
+useGetVaultQuery.fetcher = (
+  variables: GetVaultQueryVariables,
+  options?: RequestInit["headers"]
+) =>
+  fetcher<GetVaultQuery, GetVaultQueryVariables>(
+    GetVaultDocument,
+    variables,
+    options
+  )
+
+export const EventsDocument = `
+    subscription Events($addresses: [String!]!, $limit: Int!) {
+  events(
+    where: {_or: [{deposit: {is_atom_wallet: {_eq: false}}}]}
+    order_by: [{block_number: desc}]
+    limit: $limit
+  ) {
+    ...EventDetailsSubscription
+  }
+}
+    ${EventDetailsSubscriptionFragmentDoc}
+${DepositEventFragmentFragmentDoc}
+${RedemptionEventFragmentFragmentDoc}
+${AtomMetadataFragmentDoc}
+${AtomValueFragmentDoc}
+${TripleMetadataSubscriptionFragmentDoc}
+${AccountMetadataFragmentDoc}
+${TripleVaultCouterVaultDetailsWithPositionsFragmentDoc}
+${VaultDetailsWithFilteredPositionsFragmentDoc}
+${VaultBasicDetailsFragmentDoc}
+${VaultFilteredPositionsFragmentDoc}
+${PositionFieldsFragmentDoc}`
+export const AccountClaimsAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -19576,7 +27293,7 @@ export const AccountClaimsAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountClaimsFragmentDoc = {
+export const AccountClaims = {
   kind: "Document",
   definitions: [
     {
@@ -19663,7 +27380,7 @@ export const AccountClaimsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountPositionsAggregateFragmentDoc = {
+export const AccountPositionsAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -19799,7 +27516,7 @@ export const AccountPositionsAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountPositionsFragmentDoc = {
+export const AccountPositions = {
   kind: "Document",
   definitions: [
     {
@@ -19928,7 +27645,7 @@ export const AccountPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountAtomsFragmentDoc = {
+export const AccountAtoms = {
   kind: "Document",
   definitions: [
     {
@@ -20127,7 +27844,7 @@ export const AccountAtomsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountAtomsAggregateFragmentDoc = {
+export const AccountAtomsAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -20373,7 +28090,7 @@ export const AccountAtomsAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountTriplesFragmentDoc = {
+export const AccountTriples = {
   kind: "Document",
   definitions: [
     {
@@ -20508,7 +28225,7 @@ export const AccountTriplesFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountTriplesAggregateFragmentDoc = {
+export const AccountTriplesAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -20643,7 +28360,7 @@ export const AccountTriplesAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomTxnFragmentDoc = {
+export const AtomTxn = {
   kind: "Document",
   definitions: [
     {
@@ -20665,7 +28382,7 @@ export const AtomTxnFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomVaultDetailsFragmentDoc = {
+export const AtomVaultDetails = {
   kind: "Document",
   definitions: [
     {
@@ -20816,7 +28533,7 @@ export const AtomVaultDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AccountMetadataFragmentDoc = {
+export const AccountMetadata = {
   kind: "Document",
   definitions: [
     {
@@ -20839,7 +28556,7 @@ export const AccountMetadataFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomTripleFragmentDoc = {
+export const AtomTriple = {
   kind: "Document",
   definitions: [
     {
@@ -21091,7 +28808,7 @@ export const AtomTripleFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomVaultDetailsWithPositionsFragmentDoc = {
+export const AtomVaultDetailsWithPositions = {
   kind: "Document",
   definitions: [
     {
@@ -21255,7 +28972,7 @@ export const AtomVaultDetailsWithPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const DepositEventFragmentFragmentDoc = {
+export const DepositEventFragment = {
   kind: "Document",
   definitions: [
     {
@@ -21315,7 +29032,7 @@ export const DepositEventFragmentFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const RedemptionEventFragmentFragmentDoc = {
+export const RedemptionEventFragment = {
   kind: "Document",
   definitions: [
     {
@@ -21353,7 +29070,7 @@ export const RedemptionEventFragmentFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomValueFragmentDoc = {
+export const AtomValue = {
   kind: "Document",
   definitions: [
     {
@@ -21428,7 +29145,7 @@ export const AtomValueFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomMetadataFragmentDoc = {
+export const AtomMetadata = {
   kind: "Document",
   definitions: [
     {
@@ -21536,7 +29253,7 @@ export const AtomMetadataFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const PositionAggregateFieldsFragmentDoc = {
+export const PositionAggregateFields = {
   kind: "Document",
   definitions: [
     {
@@ -21574,7 +29291,7 @@ export const PositionAggregateFieldsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const PositionFieldsFragmentDoc = {
+export const PositionFields = {
   kind: "Document",
   definitions: [
     {
@@ -21622,7 +29339,7 @@ export const PositionFieldsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const TripleMetadataFragmentDoc = {
+export const TripleMetadata = {
   kind: "Document",
   definitions: [
     {
@@ -22074,7 +29791,7 @@ export const TripleMetadataFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const EventDetailsFragmentDoc = {
+export const EventDetails = {
   kind: "Document",
   definitions: [
     {
@@ -22981,7 +30698,7 @@ export const EventDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const TripleMetadataSubscriptionFragmentDoc = {
+export const TripleMetadataSubscription = {
   kind: "Document",
   definitions: [
     {
@@ -23118,7 +30835,7 @@ export const TripleMetadataSubscriptionFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultBasicDetailsFragmentDoc = {
+export const VaultBasicDetails = {
   kind: "Document",
   definitions: [
     {
@@ -23230,7 +30947,7 @@ export const VaultBasicDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultFilteredPositionsFragmentDoc = {
+export const VaultFilteredPositions = {
   kind: "Document",
   definitions: [
     {
@@ -23332,7 +31049,7 @@ export const VaultFilteredPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultDetailsWithFilteredPositionsFragmentDoc = {
+export const VaultDetailsWithFilteredPositions = {
   kind: "Document",
   definitions: [
     {
@@ -23562,7 +31279,7 @@ export const VaultDetailsWithFilteredPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const TripleVaultCouterVaultDetailsWithPositionsFragmentDoc = {
+export const TripleVaultCouterVaultDetailsWithPositions = {
   kind: "Document",
   definitions: [
     {
@@ -23918,7 +31635,7 @@ export const TripleVaultCouterVaultDetailsWithPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const EventDetailsSubscriptionFragmentDoc = {
+export const EventDetailsSubscription = {
   kind: "Document",
   definitions: [
     {
@@ -24752,7 +32469,7 @@ export const EventDetailsSubscriptionFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const FollowMetadataFragmentDoc = {
+export const FollowMetadata = {
   kind: "Document",
   definitions: [
     {
@@ -24975,7 +32692,7 @@ export const FollowMetadataFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const FollowAggregateFragmentDoc = {
+export const FollowAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -25003,7 +32720,7 @@ export const FollowAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const StatDetailsFragmentDoc = {
+export const StatDetails = {
   kind: "Document",
   definitions: [
     {
@@ -25028,7 +32745,7 @@ export const StatDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const TripleTxnFragmentDoc = {
+export const TripleTxn = {
   kind: "Document",
   definitions: [
     {
@@ -25050,7 +32767,7 @@ export const TripleTxnFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const PositionDetailsFragmentDoc = {
+export const PositionDetails = {
   kind: "Document",
   definitions: [
     {
@@ -25604,7 +33321,7 @@ export const PositionDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const TripleVaultDetailsFragmentDoc = {
+export const TripleVaultDetails = {
   kind: "Document",
   definitions: [
     {
@@ -26293,7 +34010,7 @@ export const TripleVaultDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultUnfilteredPositionsFragmentDoc = {
+export const VaultUnfilteredPositions = {
   kind: "Document",
   definitions: [
     {
@@ -26367,7 +34084,7 @@ export const VaultUnfilteredPositionsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultDetailsFragmentDoc = {
+export const VaultDetails = {
   kind: "Document",
   definitions: [
     {
@@ -26496,7 +34213,7 @@ export const VaultDetailsFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultPositionsAggregateFragmentDoc = {
+export const VaultPositionsAggregate = {
   kind: "Document",
   definitions: [
     {
@@ -26560,7 +34277,7 @@ export const VaultPositionsAggregateFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const VaultFieldsForTripleFragmentDoc = {
+export const VaultFieldsForTriple = {
   kind: "Document",
   definitions: [
     {
@@ -26747,7 +34464,7 @@ export const VaultFieldsForTripleFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const AtomMetadataMaybedeletethisFragmentDoc = {
+export const AtomMetadataMaybedeletethis = {
   kind: "Document",
   definitions: [
     {
@@ -26855,7 +34572,7 @@ export const AtomMetadataMaybedeletethisFragmentDoc = {
     }
   ]
 } as unknown as DocumentNode
-export const PinThingDocument = {
+export const PinThing = {
   kind: "Document",
   definitions: [
     {
@@ -26954,50 +34671,7 @@ export const PinThingDocument = {
     }
   ]
 } as unknown as DocumentNode
-export type PinThingMutationFn = Apollo.MutationFunction<
-  PinThingMutation,
-  PinThingMutationVariables
->
-
-/**
- * __usePinThingMutation__
- *
- * To run a mutation, you first call `usePinThingMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `usePinThingMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [pinThingMutation, { data, loading, error }] = usePinThingMutation({
- *   variables: {
- *      name: // value for 'name'
- *      description: // value for 'description'
- *      image: // value for 'image'
- *      url: // value for 'url'
- *   },
- * });
- */
-export function usePinThingMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    PinThingMutation,
-    PinThingMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useMutation<PinThingMutation, PinThingMutationVariables>(
-    PinThingDocument,
-    options
-  )
-}
-export type PinThingMutationHookResult = ReturnType<typeof usePinThingMutation>
-export type PinThingMutationResult = Apollo.MutationResult<PinThingMutation>
-export type PinThingMutationOptions = Apollo.BaseMutationOptions<
-  PinThingMutation,
-  PinThingMutationVariables
->
-export const GetAccountsDocument = {
+export const GetAccounts = {
   kind: "Document",
   definitions: [
     {
@@ -27571,85 +35245,7 @@ export const GetAccountsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountsQuery__
- *
- * To run a query within a React component, call `useGetAccountsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      claimsLimit: // value for 'claimsLimit'
- *      claimsOffset: // value for 'claimsOffset'
- *      claimsWhere: // value for 'claimsWhere'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsWhere: // value for 'positionsWhere'
- *   },
- * });
- */
-export function useGetAccountsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAccountsQuery,
-    GetAccountsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAccountsQuery, GetAccountsQueryVariables>(
-    GetAccountsDocument,
-    options
-  )
-}
-export function useGetAccountsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountsQuery,
-    GetAccountsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAccountsQuery, GetAccountsQueryVariables>(
-    GetAccountsDocument,
-    options
-  )
-}
-export function useGetAccountsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountsQuery,
-        GetAccountsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetAccountsQuery, GetAccountsQueryVariables>(
-    GetAccountsDocument,
-    options
-  )
-}
-export type GetAccountsQueryHookResult = ReturnType<typeof useGetAccountsQuery>
-export type GetAccountsLazyQueryHookResult = ReturnType<
-  typeof useGetAccountsLazyQuery
->
-export type GetAccountsSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountsSuspenseQuery
->
-export type GetAccountsQueryResult = Apollo.QueryResult<
-  GetAccountsQuery,
-  GetAccountsQueryVariables
->
-export const GetAccountsWithAggregatesDocument = {
+export const GetAccountsWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -28106,91 +35702,7 @@ export const GetAccountsWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountsWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetAccountsWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountsWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountsWithAggregatesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      claimsLimit: // value for 'claimsLimit'
- *      claimsOffset: // value for 'claimsOffset'
- *      claimsWhere: // value for 'claimsWhere'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsWhere: // value for 'positionsWhere'
- *      atomsWhere: // value for 'atomsWhere'
- *      atomsOrderBy: // value for 'atomsOrderBy'
- *      atomsLimit: // value for 'atomsLimit'
- *      atomsOffset: // value for 'atomsOffset'
- *   },
- * });
- */
-export function useGetAccountsWithAggregatesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAccountsWithAggregatesQuery,
-    GetAccountsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAccountsWithAggregatesQuery,
-    GetAccountsWithAggregatesQueryVariables
-  >(GetAccountsWithAggregatesDocument, options)
-}
-export function useGetAccountsWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountsWithAggregatesQuery,
-    GetAccountsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAccountsWithAggregatesQuery,
-    GetAccountsWithAggregatesQueryVariables
-  >(GetAccountsWithAggregatesDocument, options)
-}
-export function useGetAccountsWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountsWithAggregatesQuery,
-        GetAccountsWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAccountsWithAggregatesQuery,
-    GetAccountsWithAggregatesQueryVariables
-  >(GetAccountsWithAggregatesDocument, options)
-}
-export type GetAccountsWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetAccountsWithAggregatesQuery
->
-export type GetAccountsWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetAccountsWithAggregatesLazyQuery
->
-export type GetAccountsWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountsWithAggregatesSuspenseQuery
->
-export type GetAccountsWithAggregatesQueryResult = Apollo.QueryResult<
-  GetAccountsWithAggregatesQuery,
-  GetAccountsWithAggregatesQueryVariables
->
-export const GetAccountsCountDocument = {
+export const GetAccountsCount = {
   kind: "Document",
   definitions: [
     {
@@ -28247,78 +35759,7 @@ export const GetAccountsCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountsCountQuery__
- *
- * To run a query within a React component, call `useGetAccountsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountsCountQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetAccountsCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAccountsCountQuery,
-    GetAccountsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAccountsCountQuery, GetAccountsCountQueryVariables>(
-    GetAccountsCountDocument,
-    options
-  )
-}
-export function useGetAccountsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountsCountQuery,
-    GetAccountsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAccountsCountQuery,
-    GetAccountsCountQueryVariables
-  >(GetAccountsCountDocument, options)
-}
-export function useGetAccountsCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountsCountQuery,
-        GetAccountsCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAccountsCountQuery,
-    GetAccountsCountQueryVariables
-  >(GetAccountsCountDocument, options)
-}
-export type GetAccountsCountQueryHookResult = ReturnType<
-  typeof useGetAccountsCountQuery
->
-export type GetAccountsCountLazyQueryHookResult = ReturnType<
-  typeof useGetAccountsCountLazyQuery
->
-export type GetAccountsCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountsCountSuspenseQuery
->
-export type GetAccountsCountQueryResult = Apollo.QueryResult<
-  GetAccountsCountQuery,
-  GetAccountsCountQueryVariables
->
-export const GetAccountDocument = {
+export const GetAccount = {
   kind: "Document",
   definitions: [
     {
@@ -29372,91 +36813,7 @@ export const GetAccountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountQuery__
- *
- * To run a query within a React component, call `useGetAccountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountQuery({
- *   variables: {
- *      address: // value for 'address'
- *      claimsLimit: // value for 'claimsLimit'
- *      claimsOffset: // value for 'claimsOffset'
- *      claimsWhere: // value for 'claimsWhere'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsWhere: // value for 'positionsWhere'
- *      atomsWhere: // value for 'atomsWhere'
- *      atomsOrderBy: // value for 'atomsOrderBy'
- *      atomsLimit: // value for 'atomsLimit'
- *      atomsOffset: // value for 'atomsOffset'
- *      triplesWhere: // value for 'triplesWhere'
- *      triplesOrderBy: // value for 'triplesOrderBy'
- *      triplesLimit: // value for 'triplesLimit'
- *      triplesOffset: // value for 'triplesOffset'
- *   },
- * });
- */
-export function useGetAccountQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAccountQuery,
-    GetAccountQueryVariables
-  > &
-    (
-      | { variables: GetAccountQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAccountQuery, GetAccountQueryVariables>(
-    GetAccountDocument,
-    options
-  )
-}
-export function useGetAccountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountQuery,
-    GetAccountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAccountQuery, GetAccountQueryVariables>(
-    GetAccountDocument,
-    options
-  )
-}
-export function useGetAccountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetAccountQuery, GetAccountQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetAccountQuery, GetAccountQueryVariables>(
-    GetAccountDocument,
-    options
-  )
-}
-export type GetAccountQueryHookResult = ReturnType<typeof useGetAccountQuery>
-export type GetAccountLazyQueryHookResult = ReturnType<
-  typeof useGetAccountLazyQuery
->
-export type GetAccountSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountSuspenseQuery
->
-export type GetAccountQueryResult = Apollo.QueryResult<
-  GetAccountQuery,
-  GetAccountQueryVariables
->
-export const GetAccountWithPaginatedRelationsDocument = {
+export const GetAccountWithPaginatedRelations = {
   kind: "Document",
   definitions: [
     {
@@ -30213,98 +37570,7 @@ export const GetAccountWithPaginatedRelationsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountWithPaginatedRelationsQuery__
- *
- * To run a query within a React component, call `useGetAccountWithPaginatedRelationsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountWithPaginatedRelationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountWithPaginatedRelationsQuery({
- *   variables: {
- *      address: // value for 'address'
- *      claimsLimit: // value for 'claimsLimit'
- *      claimsOffset: // value for 'claimsOffset'
- *      claimsWhere: // value for 'claimsWhere'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsWhere: // value for 'positionsWhere'
- *      atomsLimit: // value for 'atomsLimit'
- *      atomsOffset: // value for 'atomsOffset'
- *      atomsWhere: // value for 'atomsWhere'
- *      atomsOrderBy: // value for 'atomsOrderBy'
- *      triplesLimit: // value for 'triplesLimit'
- *      triplesOffset: // value for 'triplesOffset'
- *      triplesWhere: // value for 'triplesWhere'
- *      triplesOrderBy: // value for 'triplesOrderBy'
- *   },
- * });
- */
-export function useGetAccountWithPaginatedRelationsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAccountWithPaginatedRelationsQuery,
-    GetAccountWithPaginatedRelationsQueryVariables
-  > &
-    (
-      | {
-          variables: GetAccountWithPaginatedRelationsQueryVariables
-          skip?: boolean
-        }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAccountWithPaginatedRelationsQuery,
-    GetAccountWithPaginatedRelationsQueryVariables
-  >(GetAccountWithPaginatedRelationsDocument, options)
-}
-export function useGetAccountWithPaginatedRelationsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountWithPaginatedRelationsQuery,
-    GetAccountWithPaginatedRelationsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAccountWithPaginatedRelationsQuery,
-    GetAccountWithPaginatedRelationsQueryVariables
-  >(GetAccountWithPaginatedRelationsDocument, options)
-}
-export function useGetAccountWithPaginatedRelationsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountWithPaginatedRelationsQuery,
-        GetAccountWithPaginatedRelationsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAccountWithPaginatedRelationsQuery,
-    GetAccountWithPaginatedRelationsQueryVariables
-  >(GetAccountWithPaginatedRelationsDocument, options)
-}
-export type GetAccountWithPaginatedRelationsQueryHookResult = ReturnType<
-  typeof useGetAccountWithPaginatedRelationsQuery
->
-export type GetAccountWithPaginatedRelationsLazyQueryHookResult = ReturnType<
-  typeof useGetAccountWithPaginatedRelationsLazyQuery
->
-export type GetAccountWithPaginatedRelationsSuspenseQueryHookResult =
-  ReturnType<typeof useGetAccountWithPaginatedRelationsSuspenseQuery>
-export type GetAccountWithPaginatedRelationsQueryResult = Apollo.QueryResult<
-  GetAccountWithPaginatedRelationsQuery,
-  GetAccountWithPaginatedRelationsQueryVariables
->
-export const GetAccountWithAggregatesDocument = {
+export const GetAccountWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -31113,96 +38379,7 @@ export const GetAccountWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetAccountWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountWithAggregatesQuery({
- *   variables: {
- *      address: // value for 'address'
- *      claimsLimit: // value for 'claimsLimit'
- *      claimsOffset: // value for 'claimsOffset'
- *      claimsWhere: // value for 'claimsWhere'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsWhere: // value for 'positionsWhere'
- *      atomsWhere: // value for 'atomsWhere'
- *      atomsOrderBy: // value for 'atomsOrderBy'
- *      atomsLimit: // value for 'atomsLimit'
- *      atomsOffset: // value for 'atomsOffset'
- *      triplesWhere: // value for 'triplesWhere'
- *      triplesOrderBy: // value for 'triplesOrderBy'
- *      triplesLimit: // value for 'triplesLimit'
- *      triplesOffset: // value for 'triplesOffset'
- *   },
- * });
- */
-export function useGetAccountWithAggregatesQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAccountWithAggregatesQuery,
-    GetAccountWithAggregatesQueryVariables
-  > &
-    (
-      | { variables: GetAccountWithAggregatesQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAccountWithAggregatesQuery,
-    GetAccountWithAggregatesQueryVariables
-  >(GetAccountWithAggregatesDocument, options)
-}
-export function useGetAccountWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountWithAggregatesQuery,
-    GetAccountWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAccountWithAggregatesQuery,
-    GetAccountWithAggregatesQueryVariables
-  >(GetAccountWithAggregatesDocument, options)
-}
-export function useGetAccountWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountWithAggregatesQuery,
-        GetAccountWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAccountWithAggregatesQuery,
-    GetAccountWithAggregatesQueryVariables
-  >(GetAccountWithAggregatesDocument, options)
-}
-export type GetAccountWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetAccountWithAggregatesQuery
->
-export type GetAccountWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetAccountWithAggregatesLazyQuery
->
-export type GetAccountWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountWithAggregatesSuspenseQuery
->
-export type GetAccountWithAggregatesQueryResult = Apollo.QueryResult<
-  GetAccountWithAggregatesQuery,
-  GetAccountWithAggregatesQueryVariables
->
-export const GetAtomsDocument = {
+export const GetAtoms = {
   kind: "Document",
   definitions: [
     {
@@ -31878,73 +39055,7 @@ export const GetAtomsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomsQuery__
- *
- * To run a query within a React component, call `useGetAtomsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetAtomsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetAtomsQuery, GetAtomsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAtomsQuery, GetAtomsQueryVariables>(
-    GetAtomsDocument,
-    options
-  )
-}
-export function useGetAtomsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomsQuery,
-    GetAtomsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAtomsQuery, GetAtomsQueryVariables>(
-    GetAtomsDocument,
-    options
-  )
-}
-export function useGetAtomsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetAtomsQuery, GetAtomsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetAtomsQuery, GetAtomsQueryVariables>(
-    GetAtomsDocument,
-    options
-  )
-}
-export type GetAtomsQueryHookResult = ReturnType<typeof useGetAtomsQuery>
-export type GetAtomsLazyQueryHookResult = ReturnType<
-  typeof useGetAtomsLazyQuery
->
-export type GetAtomsSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomsSuspenseQuery
->
-export type GetAtomsQueryResult = Apollo.QueryResult<
-  GetAtomsQuery,
-  GetAtomsQueryVariables
->
-export const GetAtomsWithPositionsDocument = {
+export const GetAtomsWithPositions = {
   kind: "Document",
   definitions: [
     {
@@ -32472,82 +39583,7 @@ export const GetAtomsWithPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomsWithPositionsQuery__
- *
- * To run a query within a React component, call `useGetAtomsWithPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomsWithPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomsWithPositionsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetAtomsWithPositionsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAtomsWithPositionsQuery,
-    GetAtomsWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAtomsWithPositionsQuery,
-    GetAtomsWithPositionsQueryVariables
-  >(GetAtomsWithPositionsDocument, options)
-}
-export function useGetAtomsWithPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomsWithPositionsQuery,
-    GetAtomsWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAtomsWithPositionsQuery,
-    GetAtomsWithPositionsQueryVariables
-  >(GetAtomsWithPositionsDocument, options)
-}
-export function useGetAtomsWithPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomsWithPositionsQuery,
-        GetAtomsWithPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomsWithPositionsQuery,
-    GetAtomsWithPositionsQueryVariables
-  >(GetAtomsWithPositionsDocument, options)
-}
-export type GetAtomsWithPositionsQueryHookResult = ReturnType<
-  typeof useGetAtomsWithPositionsQuery
->
-export type GetAtomsWithPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetAtomsWithPositionsLazyQuery
->
-export type GetAtomsWithPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomsWithPositionsSuspenseQuery
->
-export type GetAtomsWithPositionsQueryResult = Apollo.QueryResult<
-  GetAtomsWithPositionsQuery,
-  GetAtomsWithPositionsQueryVariables
->
-export const GetAtomsWithAggregatesDocument = {
+export const GetAtomsWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -32979,81 +40015,7 @@ export const GetAtomsWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomsWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetAtomsWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomsWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomsWithAggregatesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetAtomsWithAggregatesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAtomsWithAggregatesQuery,
-    GetAtomsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAtomsWithAggregatesQuery,
-    GetAtomsWithAggregatesQueryVariables
-  >(GetAtomsWithAggregatesDocument, options)
-}
-export function useGetAtomsWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomsWithAggregatesQuery,
-    GetAtomsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAtomsWithAggregatesQuery,
-    GetAtomsWithAggregatesQueryVariables
-  >(GetAtomsWithAggregatesDocument, options)
-}
-export function useGetAtomsWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomsWithAggregatesQuery,
-        GetAtomsWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomsWithAggregatesQuery,
-    GetAtomsWithAggregatesQueryVariables
-  >(GetAtomsWithAggregatesDocument, options)
-}
-export type GetAtomsWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetAtomsWithAggregatesQuery
->
-export type GetAtomsWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetAtomsWithAggregatesLazyQuery
->
-export type GetAtomsWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomsWithAggregatesSuspenseQuery
->
-export type GetAtomsWithAggregatesQueryResult = Apollo.QueryResult<
-  GetAtomsWithAggregatesQuery,
-  GetAtomsWithAggregatesQueryVariables
->
-export const GetAtomsCountDocument = {
+export const GetAtomsCount = {
   kind: "Document",
   definitions: [
     {
@@ -33110,78 +40072,7 @@ export const GetAtomsCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomsCountQuery__
- *
- * To run a query within a React component, call `useGetAtomsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomsCountQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetAtomsCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAtomsCountQuery,
-    GetAtomsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAtomsCountQuery, GetAtomsCountQueryVariables>(
-    GetAtomsCountDocument,
-    options
-  )
-}
-export function useGetAtomsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomsCountQuery,
-    GetAtomsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAtomsCountQuery, GetAtomsCountQueryVariables>(
-    GetAtomsCountDocument,
-    options
-  )
-}
-export function useGetAtomsCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomsCountQuery,
-        GetAtomsCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomsCountQuery,
-    GetAtomsCountQueryVariables
-  >(GetAtomsCountDocument, options)
-}
-export type GetAtomsCountQueryHookResult = ReturnType<
-  typeof useGetAtomsCountQuery
->
-export type GetAtomsCountLazyQueryHookResult = ReturnType<
-  typeof useGetAtomsCountLazyQuery
->
-export type GetAtomsCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomsCountSuspenseQuery
->
-export type GetAtomsCountQueryResult = Apollo.QueryResult<
-  GetAtomsCountQuery,
-  GetAtomsCountQueryVariables
->
-export const GetAtomDocument = {
+export const GetAtom = {
   kind: "Document",
   definitions: [
     {
@@ -33767,66 +40658,7 @@ export const GetAtomDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomQuery__
- *
- * To run a query within a React component, call `useGetAtomQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetAtomQuery(
-  baseOptions: Apollo.QueryHookOptions<GetAtomQuery, GetAtomQueryVariables> &
-    ({ variables: GetAtomQueryVariables; skip?: boolean } | { skip: boolean })
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAtomQuery, GetAtomQueryVariables>(
-    GetAtomDocument,
-    options
-  )
-}
-export function useGetAtomLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<GetAtomQuery, GetAtomQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAtomQuery, GetAtomQueryVariables>(
-    GetAtomDocument,
-    options
-  )
-}
-export function useGetAtomSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetAtomQuery, GetAtomQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetAtomQuery, GetAtomQueryVariables>(
-    GetAtomDocument,
-    options
-  )
-}
-export type GetAtomQueryHookResult = ReturnType<typeof useGetAtomQuery>
-export type GetAtomLazyQueryHookResult = ReturnType<typeof useGetAtomLazyQuery>
-export type GetAtomSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomSuspenseQuery
->
-export type GetAtomQueryResult = Apollo.QueryResult<
-  GetAtomQuery,
-  GetAtomQueryVariables
->
-export const GetAtomByDataDocument = {
+export const GetAtomByData = {
   kind: "Document",
   definitions: [
     {
@@ -34430,82 +41262,7 @@ export const GetAtomByDataDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomByDataQuery__
- *
- * To run a query within a React component, call `useGetAtomByDataQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomByDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomByDataQuery({
- *   variables: {
- *      data: // value for 'data'
- *   },
- * });
- */
-export function useGetAtomByDataQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAtomByDataQuery,
-    GetAtomByDataQueryVariables
-  > &
-    (
-      | { variables: GetAtomByDataQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAtomByDataQuery, GetAtomByDataQueryVariables>(
-    GetAtomByDataDocument,
-    options
-  )
-}
-export function useGetAtomByDataLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomByDataQuery,
-    GetAtomByDataQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAtomByDataQuery, GetAtomByDataQueryVariables>(
-    GetAtomByDataDocument,
-    options
-  )
-}
-export function useGetAtomByDataSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomByDataQuery,
-        GetAtomByDataQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomByDataQuery,
-    GetAtomByDataQueryVariables
-  >(GetAtomByDataDocument, options)
-}
-export type GetAtomByDataQueryHookResult = ReturnType<
-  typeof useGetAtomByDataQuery
->
-export type GetAtomByDataLazyQueryHookResult = ReturnType<
-  typeof useGetAtomByDataLazyQuery
->
-export type GetAtomByDataSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomByDataSuspenseQuery
->
-export type GetAtomByDataQueryResult = Apollo.QueryResult<
-  GetAtomByDataQuery,
-  GetAtomByDataQueryVariables
->
-export const GetVerifiedAtomDetailsDocument = {
+export const GetVerifiedAtomDetails = {
   kind: "Document",
   definitions: [
     {
@@ -35176,83 +41933,7 @@ export const GetVerifiedAtomDetailsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetVerifiedAtomDetailsQuery__
- *
- * To run a query within a React component, call `useGetVerifiedAtomDetailsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetVerifiedAtomDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetVerifiedAtomDetailsQuery({
- *   variables: {
- *      id: // value for 'id'
- *      userPositionAddress: // value for 'userPositionAddress'
- *   },
- * });
- */
-export function useGetVerifiedAtomDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetVerifiedAtomDetailsQuery,
-    GetVerifiedAtomDetailsQueryVariables
-  > &
-    (
-      | { variables: GetVerifiedAtomDetailsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetVerifiedAtomDetailsQuery,
-    GetVerifiedAtomDetailsQueryVariables
-  >(GetVerifiedAtomDetailsDocument, options)
-}
-export function useGetVerifiedAtomDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetVerifiedAtomDetailsQuery,
-    GetVerifiedAtomDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetVerifiedAtomDetailsQuery,
-    GetVerifiedAtomDetailsQueryVariables
-  >(GetVerifiedAtomDetailsDocument, options)
-}
-export function useGetVerifiedAtomDetailsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetVerifiedAtomDetailsQuery,
-        GetVerifiedAtomDetailsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetVerifiedAtomDetailsQuery,
-    GetVerifiedAtomDetailsQueryVariables
-  >(GetVerifiedAtomDetailsDocument, options)
-}
-export type GetVerifiedAtomDetailsQueryHookResult = ReturnType<
-  typeof useGetVerifiedAtomDetailsQuery
->
-export type GetVerifiedAtomDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetVerifiedAtomDetailsLazyQuery
->
-export type GetVerifiedAtomDetailsSuspenseQueryHookResult = ReturnType<
-  typeof useGetVerifiedAtomDetailsSuspenseQuery
->
-export type GetVerifiedAtomDetailsQueryResult = Apollo.QueryResult<
-  GetVerifiedAtomDetailsQuery,
-  GetVerifiedAtomDetailsQueryVariables
->
-export const GetAtomDetailsDocument = {
+export const GetAtomDetails = {
   kind: "Document",
   definitions: [
     {
@@ -35665,83 +42346,7 @@ export const GetAtomDetailsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomDetailsQuery__
- *
- * To run a query within a React component, call `useGetAtomDetailsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomDetailsQuery({
- *   variables: {
- *      id: // value for 'id'
- *      userPositionAddress: // value for 'userPositionAddress'
- *   },
- * });
- */
-export function useGetAtomDetailsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAtomDetailsQuery,
-    GetAtomDetailsQueryVariables
-  > &
-    (
-      | { variables: GetAtomDetailsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAtomDetailsQuery, GetAtomDetailsQueryVariables>(
-    GetAtomDetailsDocument,
-    options
-  )
-}
-export function useGetAtomDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomDetailsQuery,
-    GetAtomDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAtomDetailsQuery, GetAtomDetailsQueryVariables>(
-    GetAtomDetailsDocument,
-    options
-  )
-}
-export function useGetAtomDetailsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomDetailsQuery,
-        GetAtomDetailsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomDetailsQuery,
-    GetAtomDetailsQueryVariables
-  >(GetAtomDetailsDocument, options)
-}
-export type GetAtomDetailsQueryHookResult = ReturnType<
-  typeof useGetAtomDetailsQuery
->
-export type GetAtomDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetAtomDetailsLazyQuery
->
-export type GetAtomDetailsSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomDetailsSuspenseQuery
->
-export type GetAtomDetailsQueryResult = Apollo.QueryResult<
-  GetAtomDetailsQuery,
-  GetAtomDetailsQueryVariables
->
-export const GetAtomsByCreatorDocument = {
+export const GetAtomsByCreator = {
   kind: "Document",
   definitions: [
     {
@@ -35945,82 +42550,7 @@ export const GetAtomsByCreatorDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomsByCreatorQuery__
- *
- * To run a query within a React component, call `useGetAtomsByCreatorQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomsByCreatorQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomsByCreatorQuery({
- *   variables: {
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetAtomsByCreatorQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAtomsByCreatorQuery,
-    GetAtomsByCreatorQueryVariables
-  > &
-    (
-      | { variables: GetAtomsByCreatorQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAtomsByCreatorQuery,
-    GetAtomsByCreatorQueryVariables
-  >(GetAtomsByCreatorDocument, options)
-}
-export function useGetAtomsByCreatorLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomsByCreatorQuery,
-    GetAtomsByCreatorQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAtomsByCreatorQuery,
-    GetAtomsByCreatorQueryVariables
-  >(GetAtomsByCreatorDocument, options)
-}
-export function useGetAtomsByCreatorSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomsByCreatorQuery,
-        GetAtomsByCreatorQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomsByCreatorQuery,
-    GetAtomsByCreatorQueryVariables
-  >(GetAtomsByCreatorDocument, options)
-}
-export type GetAtomsByCreatorQueryHookResult = ReturnType<
-  typeof useGetAtomsByCreatorQuery
->
-export type GetAtomsByCreatorLazyQueryHookResult = ReturnType<
-  typeof useGetAtomsByCreatorLazyQuery
->
-export type GetAtomsByCreatorSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomsByCreatorSuspenseQuery
->
-export type GetAtomsByCreatorQueryResult = Apollo.QueryResult<
-  GetAtomsByCreatorQuery,
-  GetAtomsByCreatorQueryVariables
->
-export const GetClaimsByAddressDocument = {
+export const GetClaimsByAddress = {
   kind: "Document",
   definitions: [
     {
@@ -36216,78 +42746,7 @@ export const GetClaimsByAddressDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetClaimsByAddressQuery__
- *
- * To run a query within a React component, call `useGetClaimsByAddressQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetClaimsByAddressQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetClaimsByAddressQuery({
- *   variables: {
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetClaimsByAddressQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetClaimsByAddressQuery,
-    GetClaimsByAddressQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetClaimsByAddressQuery,
-    GetClaimsByAddressQueryVariables
-  >(GetClaimsByAddressDocument, options)
-}
-export function useGetClaimsByAddressLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetClaimsByAddressQuery,
-    GetClaimsByAddressQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetClaimsByAddressQuery,
-    GetClaimsByAddressQueryVariables
-  >(GetClaimsByAddressDocument, options)
-}
-export function useGetClaimsByAddressSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetClaimsByAddressQuery,
-        GetClaimsByAddressQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetClaimsByAddressQuery,
-    GetClaimsByAddressQueryVariables
-  >(GetClaimsByAddressDocument, options)
-}
-export type GetClaimsByAddressQueryHookResult = ReturnType<
-  typeof useGetClaimsByAddressQuery
->
-export type GetClaimsByAddressLazyQueryHookResult = ReturnType<
-  typeof useGetClaimsByAddressLazyQuery
->
-export type GetClaimsByAddressSuspenseQueryHookResult = ReturnType<
-  typeof useGetClaimsByAddressSuspenseQuery
->
-export type GetClaimsByAddressQueryResult = Apollo.QueryResult<
-  GetClaimsByAddressQuery,
-  GetClaimsByAddressQueryVariables
->
-export const GetClaimsByUriDocument = {
+export const GetClaimsByUri = {
   kind: "Document",
   definitions: [
     {
@@ -37448,79 +43907,7 @@ export const GetClaimsByUriDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetClaimsByUriQuery__
- *
- * To run a query within a React component, call `useGetClaimsByUriQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetClaimsByUriQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetClaimsByUriQuery({
- *   variables: {
- *      address: // value for 'address'
- *      uri: // value for 'uri'
- *   },
- * });
- */
-export function useGetClaimsByUriQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetClaimsByUriQuery,
-    GetClaimsByUriQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetClaimsByUriQuery, GetClaimsByUriQueryVariables>(
-    GetClaimsByUriDocument,
-    options
-  )
-}
-export function useGetClaimsByUriLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetClaimsByUriQuery,
-    GetClaimsByUriQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetClaimsByUriQuery, GetClaimsByUriQueryVariables>(
-    GetClaimsByUriDocument,
-    options
-  )
-}
-export function useGetClaimsByUriSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetClaimsByUriQuery,
-        GetClaimsByUriQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetClaimsByUriQuery,
-    GetClaimsByUriQueryVariables
-  >(GetClaimsByUriDocument, options)
-}
-export type GetClaimsByUriQueryHookResult = ReturnType<
-  typeof useGetClaimsByUriQuery
->
-export type GetClaimsByUriLazyQueryHookResult = ReturnType<
-  typeof useGetClaimsByUriLazyQuery
->
-export type GetClaimsByUriSuspenseQueryHookResult = ReturnType<
-  typeof useGetClaimsByUriSuspenseQuery
->
-export type GetClaimsByUriQueryResult = Apollo.QueryResult<
-  GetClaimsByUriQuery,
-  GetClaimsByUriQueryVariables
->
-export const GetEventsDocument = {
+export const GetEvents = {
   kind: "Document",
   definitions: [
     {
@@ -38694,74 +45081,7 @@ export const GetEventsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetEventsQuery__
- *
- * To run a query within a React component, call `useGetEventsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      addresses: // value for 'addresses'
- *   },
- * });
- */
-export function useGetEventsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetEventsQuery, GetEventsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetEventsQuery, GetEventsQueryVariables>(
-    GetEventsDocument,
-    options
-  )
-}
-export function useGetEventsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetEventsQuery,
-    GetEventsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetEventsQuery, GetEventsQueryVariables>(
-    GetEventsDocument,
-    options
-  )
-}
-export function useGetEventsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetEventsQuery, GetEventsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetEventsQuery, GetEventsQueryVariables>(
-    GetEventsDocument,
-    options
-  )
-}
-export type GetEventsQueryHookResult = ReturnType<typeof useGetEventsQuery>
-export type GetEventsLazyQueryHookResult = ReturnType<
-  typeof useGetEventsLazyQuery
->
-export type GetEventsSuspenseQueryHookResult = ReturnType<
-  typeof useGetEventsSuspenseQuery
->
-export type GetEventsQueryResult = Apollo.QueryResult<
-  GetEventsQuery,
-  GetEventsQueryVariables
->
-export const GetEventsWithAggregatesDocument = {
+export const GetEventsWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -39841,82 +46161,7 @@ export const GetEventsWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetEventsWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetEventsWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetEventsWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventsWithAggregatesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      addresses: // value for 'addresses'
- *   },
- * });
- */
-export function useGetEventsWithAggregatesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetEventsWithAggregatesQuery,
-    GetEventsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetEventsWithAggregatesQuery,
-    GetEventsWithAggregatesQueryVariables
-  >(GetEventsWithAggregatesDocument, options)
-}
-export function useGetEventsWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetEventsWithAggregatesQuery,
-    GetEventsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetEventsWithAggregatesQuery,
-    GetEventsWithAggregatesQueryVariables
-  >(GetEventsWithAggregatesDocument, options)
-}
-export function useGetEventsWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetEventsWithAggregatesQuery,
-        GetEventsWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetEventsWithAggregatesQuery,
-    GetEventsWithAggregatesQueryVariables
-  >(GetEventsWithAggregatesDocument, options)
-}
-export type GetEventsWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetEventsWithAggregatesQuery
->
-export type GetEventsWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetEventsWithAggregatesLazyQuery
->
-export type GetEventsWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetEventsWithAggregatesSuspenseQuery
->
-export type GetEventsWithAggregatesQueryResult = Apollo.QueryResult<
-  GetEventsWithAggregatesQuery,
-  GetEventsWithAggregatesQueryVariables
->
-export const GetEventsCountDocument = {
+export const GetEventsCount = {
   kind: "Document",
   definitions: [
     {
@@ -39973,78 +46218,7 @@ export const GetEventsCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetEventsCountQuery__
- *
- * To run a query within a React component, call `useGetEventsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetEventsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventsCountQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetEventsCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetEventsCountQuery,
-    GetEventsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetEventsCountQuery, GetEventsCountQueryVariables>(
-    GetEventsCountDocument,
-    options
-  )
-}
-export function useGetEventsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetEventsCountQuery,
-    GetEventsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetEventsCountQuery, GetEventsCountQueryVariables>(
-    GetEventsCountDocument,
-    options
-  )
-}
-export function useGetEventsCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetEventsCountQuery,
-        GetEventsCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetEventsCountQuery,
-    GetEventsCountQueryVariables
-  >(GetEventsCountDocument, options)
-}
-export type GetEventsCountQueryHookResult = ReturnType<
-  typeof useGetEventsCountQuery
->
-export type GetEventsCountLazyQueryHookResult = ReturnType<
-  typeof useGetEventsCountLazyQuery
->
-export type GetEventsCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetEventsCountSuspenseQuery
->
-export type GetEventsCountQueryResult = Apollo.QueryResult<
-  GetEventsCountQuery,
-  GetEventsCountQueryVariables
->
-export const GetEventsDataDocument = {
+export const GetEventsData = {
   kind: "Document",
   definitions: [
     {
@@ -40148,78 +46322,7 @@ export const GetEventsDataDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetEventsDataQuery__
- *
- * To run a query within a React component, call `useGetEventsDataQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetEventsDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventsDataQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetEventsDataQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetEventsDataQuery,
-    GetEventsDataQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetEventsDataQuery, GetEventsDataQueryVariables>(
-    GetEventsDataDocument,
-    options
-  )
-}
-export function useGetEventsDataLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetEventsDataQuery,
-    GetEventsDataQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetEventsDataQuery, GetEventsDataQueryVariables>(
-    GetEventsDataDocument,
-    options
-  )
-}
-export function useGetEventsDataSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetEventsDataQuery,
-        GetEventsDataQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetEventsDataQuery,
-    GetEventsDataQueryVariables
-  >(GetEventsDataDocument, options)
-}
-export type GetEventsDataQueryHookResult = ReturnType<
-  typeof useGetEventsDataQuery
->
-export type GetEventsDataLazyQueryHookResult = ReturnType<
-  typeof useGetEventsDataLazyQuery
->
-export type GetEventsDataSuspenseQueryHookResult = ReturnType<
-  typeof useGetEventsDataSuspenseQuery
->
-export type GetEventsDataQueryResult = Apollo.QueryResult<
-  GetEventsDataQuery,
-  GetEventsDataQueryVariables
->
-export const GetDebugEventsDocument = {
+export const GetDebugEvents = {
   kind: "Document",
   definitions: [
     {
@@ -40336,78 +46439,7 @@ export const GetDebugEventsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetDebugEventsQuery__
- *
- * To run a query within a React component, call `useGetDebugEventsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetDebugEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetDebugEventsQuery({
- *   variables: {
- *      addresses: // value for 'addresses'
- *   },
- * });
- */
-export function useGetDebugEventsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetDebugEventsQuery,
-    GetDebugEventsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetDebugEventsQuery, GetDebugEventsQueryVariables>(
-    GetDebugEventsDocument,
-    options
-  )
-}
-export function useGetDebugEventsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetDebugEventsQuery,
-    GetDebugEventsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetDebugEventsQuery, GetDebugEventsQueryVariables>(
-    GetDebugEventsDocument,
-    options
-  )
-}
-export function useGetDebugEventsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetDebugEventsQuery,
-        GetDebugEventsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetDebugEventsQuery,
-    GetDebugEventsQueryVariables
-  >(GetDebugEventsDocument, options)
-}
-export type GetDebugEventsQueryHookResult = ReturnType<
-  typeof useGetDebugEventsQuery
->
-export type GetDebugEventsLazyQueryHookResult = ReturnType<
-  typeof useGetDebugEventsLazyQuery
->
-export type GetDebugEventsSuspenseQueryHookResult = ReturnType<
-  typeof useGetDebugEventsSuspenseQuery
->
-export type GetDebugEventsQueryResult = Apollo.QueryResult<
-  GetDebugEventsQuery,
-  GetDebugEventsQueryVariables
->
-export const GetFollowingPositionsDocument = {
+export const GetFollowingPositions = {
   kind: "Document",
   definitions: [
     {
@@ -41084,87 +47116,7 @@ export const GetFollowingPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFollowingPositionsQuery__
- *
- * To run a query within a React component, call `useGetFollowingPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFollowingPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFollowingPositionsQuery({
- *   variables: {
- *      subjectId: // value for 'subjectId'
- *      predicateId: // value for 'predicateId'
- *      address: // value for 'address'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      positionsOrderBy: // value for 'positionsOrderBy'
- *   },
- * });
- */
-export function useGetFollowingPositionsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFollowingPositionsQuery,
-    GetFollowingPositionsQueryVariables
-  > &
-    (
-      | { variables: GetFollowingPositionsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetFollowingPositionsQuery,
-    GetFollowingPositionsQueryVariables
-  >(GetFollowingPositionsDocument, options)
-}
-export function useGetFollowingPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFollowingPositionsQuery,
-    GetFollowingPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFollowingPositionsQuery,
-    GetFollowingPositionsQueryVariables
-  >(GetFollowingPositionsDocument, options)
-}
-export function useGetFollowingPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFollowingPositionsQuery,
-        GetFollowingPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFollowingPositionsQuery,
-    GetFollowingPositionsQueryVariables
-  >(GetFollowingPositionsDocument, options)
-}
-export type GetFollowingPositionsQueryHookResult = ReturnType<
-  typeof useGetFollowingPositionsQuery
->
-export type GetFollowingPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetFollowingPositionsLazyQuery
->
-export type GetFollowingPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetFollowingPositionsSuspenseQuery
->
-export type GetFollowingPositionsQueryResult = Apollo.QueryResult<
-  GetFollowingPositionsQuery,
-  GetFollowingPositionsQueryVariables
->
-export const GetFollowerPositionsDocument = {
+export const GetFollowerPositions = {
   kind: "Document",
   definitions: [
     {
@@ -41693,88 +47645,7 @@ export const GetFollowerPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFollowerPositionsQuery__
- *
- * To run a query within a React component, call `useGetFollowerPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFollowerPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFollowerPositionsQuery({
- *   variables: {
- *      subjectId: // value for 'subjectId'
- *      predicateId: // value for 'predicateId'
- *      objectId: // value for 'objectId'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsOrderBy: // value for 'positionsOrderBy'
- *      positionsWhere: // value for 'positionsWhere'
- *   },
- * });
- */
-export function useGetFollowerPositionsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFollowerPositionsQuery,
-    GetFollowerPositionsQueryVariables
-  > &
-    (
-      | { variables: GetFollowerPositionsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetFollowerPositionsQuery,
-    GetFollowerPositionsQueryVariables
-  >(GetFollowerPositionsDocument, options)
-}
-export function useGetFollowerPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFollowerPositionsQuery,
-    GetFollowerPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFollowerPositionsQuery,
-    GetFollowerPositionsQueryVariables
-  >(GetFollowerPositionsDocument, options)
-}
-export function useGetFollowerPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFollowerPositionsQuery,
-        GetFollowerPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFollowerPositionsQuery,
-    GetFollowerPositionsQueryVariables
-  >(GetFollowerPositionsDocument, options)
-}
-export type GetFollowerPositionsQueryHookResult = ReturnType<
-  typeof useGetFollowerPositionsQuery
->
-export type GetFollowerPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetFollowerPositionsLazyQuery
->
-export type GetFollowerPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetFollowerPositionsSuspenseQuery
->
-export type GetFollowerPositionsQueryResult = Apollo.QueryResult<
-  GetFollowerPositionsQuery,
-  GetFollowerPositionsQueryVariables
->
-export const GetConnectionsDocument = {
+export const GetConnections = {
   kind: "Document",
   definitions: [
     {
@@ -42590,89 +48461,7 @@ export const GetConnectionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetConnectionsQuery__
- *
- * To run a query within a React component, call `useGetConnectionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetConnectionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetConnectionsQuery({
- *   variables: {
- *      subjectId: // value for 'subjectId'
- *      predicateId: // value for 'predicateId'
- *      objectId: // value for 'objectId'
- *      addresses: // value for 'addresses'
- *      positionsLimit: // value for 'positionsLimit'
- *      positionsOffset: // value for 'positionsOffset'
- *      positionsOrderBy: // value for 'positionsOrderBy'
- *      positionsWhere: // value for 'positionsWhere'
- *   },
- * });
- */
-export function useGetConnectionsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetConnectionsQuery,
-    GetConnectionsQueryVariables
-  > &
-    (
-      | { variables: GetConnectionsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetConnectionsQuery, GetConnectionsQueryVariables>(
-    GetConnectionsDocument,
-    options
-  )
-}
-export function useGetConnectionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetConnectionsQuery,
-    GetConnectionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetConnectionsQuery, GetConnectionsQueryVariables>(
-    GetConnectionsDocument,
-    options
-  )
-}
-export function useGetConnectionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetConnectionsQuery,
-        GetConnectionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetConnectionsQuery,
-    GetConnectionsQueryVariables
-  >(GetConnectionsDocument, options)
-}
-export type GetConnectionsQueryHookResult = ReturnType<
-  typeof useGetConnectionsQuery
->
-export type GetConnectionsLazyQueryHookResult = ReturnType<
-  typeof useGetConnectionsLazyQuery
->
-export type GetConnectionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetConnectionsSuspenseQuery
->
-export type GetConnectionsQueryResult = Apollo.QueryResult<
-  GetConnectionsQuery,
-  GetConnectionsQueryVariables
->
-export const GetConnectionsCountDocument = {
+export const GetConnectionsCount = {
   kind: "Document",
   definitions: [
     {
@@ -43065,85 +48854,7 @@ export const GetConnectionsCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetConnectionsCountQuery__
- *
- * To run a query within a React component, call `useGetConnectionsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetConnectionsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetConnectionsCountQuery({
- *   variables: {
- *      subjectId: // value for 'subjectId'
- *      predicateId: // value for 'predicateId'
- *      objectId: // value for 'objectId'
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetConnectionsCountQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetConnectionsCountQuery,
-    GetConnectionsCountQueryVariables
-  > &
-    (
-      | { variables: GetConnectionsCountQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetConnectionsCountQuery,
-    GetConnectionsCountQueryVariables
-  >(GetConnectionsCountDocument, options)
-}
-export function useGetConnectionsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetConnectionsCountQuery,
-    GetConnectionsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetConnectionsCountQuery,
-    GetConnectionsCountQueryVariables
-  >(GetConnectionsCountDocument, options)
-}
-export function useGetConnectionsCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetConnectionsCountQuery,
-        GetConnectionsCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetConnectionsCountQuery,
-    GetConnectionsCountQueryVariables
-  >(GetConnectionsCountDocument, options)
-}
-export type GetConnectionsCountQueryHookResult = ReturnType<
-  typeof useGetConnectionsCountQuery
->
-export type GetConnectionsCountLazyQueryHookResult = ReturnType<
-  typeof useGetConnectionsCountLazyQuery
->
-export type GetConnectionsCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetConnectionsCountSuspenseQuery
->
-export type GetConnectionsCountQueryResult = Apollo.QueryResult<
-  GetConnectionsCountQuery,
-  GetConnectionsCountQueryVariables
->
-export const GetFollowingsFromAddressDocument = {
+export const GetFollowingsFromAddress = {
   kind: "Document",
   definitions: [
     {
@@ -43980,82 +49691,7 @@ export const GetFollowingsFromAddressDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFollowingsFromAddressQuery__
- *
- * To run a query within a React component, call `useGetFollowingsFromAddressQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFollowingsFromAddressQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFollowingsFromAddressQuery({
- *   variables: {
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetFollowingsFromAddressQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFollowingsFromAddressQuery,
-    GetFollowingsFromAddressQueryVariables
-  > &
-    (
-      | { variables: GetFollowingsFromAddressQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetFollowingsFromAddressQuery,
-    GetFollowingsFromAddressQueryVariables
-  >(GetFollowingsFromAddressDocument, options)
-}
-export function useGetFollowingsFromAddressLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFollowingsFromAddressQuery,
-    GetFollowingsFromAddressQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFollowingsFromAddressQuery,
-    GetFollowingsFromAddressQueryVariables
-  >(GetFollowingsFromAddressDocument, options)
-}
-export function useGetFollowingsFromAddressSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFollowingsFromAddressQuery,
-        GetFollowingsFromAddressQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFollowingsFromAddressQuery,
-    GetFollowingsFromAddressQueryVariables
-  >(GetFollowingsFromAddressDocument, options)
-}
-export type GetFollowingsFromAddressQueryHookResult = ReturnType<
-  typeof useGetFollowingsFromAddressQuery
->
-export type GetFollowingsFromAddressLazyQueryHookResult = ReturnType<
-  typeof useGetFollowingsFromAddressLazyQuery
->
-export type GetFollowingsFromAddressSuspenseQueryHookResult = ReturnType<
-  typeof useGetFollowingsFromAddressSuspenseQuery
->
-export type GetFollowingsFromAddressQueryResult = Apollo.QueryResult<
-  GetFollowingsFromAddressQuery,
-  GetFollowingsFromAddressQueryVariables
->
-export const GetFollowersFromAddressDocument = {
+export const GetFollowersFromAddress = {
   kind: "Document",
   definitions: [
     {
@@ -44280,82 +49916,7 @@ export const GetFollowersFromAddressDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFollowersFromAddressQuery__
- *
- * To run a query within a React component, call `useGetFollowersFromAddressQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFollowersFromAddressQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFollowersFromAddressQuery({
- *   variables: {
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetFollowersFromAddressQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFollowersFromAddressQuery,
-    GetFollowersFromAddressQueryVariables
-  > &
-    (
-      | { variables: GetFollowersFromAddressQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetFollowersFromAddressQuery,
-    GetFollowersFromAddressQueryVariables
-  >(GetFollowersFromAddressDocument, options)
-}
-export function useGetFollowersFromAddressLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFollowersFromAddressQuery,
-    GetFollowersFromAddressQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFollowersFromAddressQuery,
-    GetFollowersFromAddressQueryVariables
-  >(GetFollowersFromAddressDocument, options)
-}
-export function useGetFollowersFromAddressSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFollowersFromAddressQuery,
-        GetFollowersFromAddressQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFollowersFromAddressQuery,
-    GetFollowersFromAddressQueryVariables
-  >(GetFollowersFromAddressDocument, options)
-}
-export type GetFollowersFromAddressQueryHookResult = ReturnType<
-  typeof useGetFollowersFromAddressQuery
->
-export type GetFollowersFromAddressLazyQueryHookResult = ReturnType<
-  typeof useGetFollowersFromAddressLazyQuery
->
-export type GetFollowersFromAddressSuspenseQueryHookResult = ReturnType<
-  typeof useGetFollowersFromAddressSuspenseQuery
->
-export type GetFollowersFromAddressQueryResult = Apollo.QueryResult<
-  GetFollowersFromAddressQuery,
-  GetFollowersFromAddressQueryVariables
->
-export const GetFollowingsTriplesDocument = {
+export const GetFollowingsTriples = {
   kind: "Document",
   definitions: [
     {
@@ -44516,82 +50077,7 @@ export const GetFollowingsTriplesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFollowingsTriplesQuery__
- *
- * To run a query within a React component, call `useGetFollowingsTriplesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFollowingsTriplesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFollowingsTriplesQuery({
- *   variables: {
- *      accountId: // value for 'accountId'
- *   },
- * });
- */
-export function useGetFollowingsTriplesQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFollowingsTriplesQuery,
-    GetFollowingsTriplesQueryVariables
-  > &
-    (
-      | { variables: GetFollowingsTriplesQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetFollowingsTriplesQuery,
-    GetFollowingsTriplesQueryVariables
-  >(GetFollowingsTriplesDocument, options)
-}
-export function useGetFollowingsTriplesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFollowingsTriplesQuery,
-    GetFollowingsTriplesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFollowingsTriplesQuery,
-    GetFollowingsTriplesQueryVariables
-  >(GetFollowingsTriplesDocument, options)
-}
-export function useGetFollowingsTriplesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFollowingsTriplesQuery,
-        GetFollowingsTriplesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFollowingsTriplesQuery,
-    GetFollowingsTriplesQueryVariables
-  >(GetFollowingsTriplesDocument, options)
-}
-export type GetFollowingsTriplesQueryHookResult = ReturnType<
-  typeof useGetFollowingsTriplesQuery
->
-export type GetFollowingsTriplesLazyQueryHookResult = ReturnType<
-  typeof useGetFollowingsTriplesLazyQuery
->
-export type GetFollowingsTriplesSuspenseQueryHookResult = ReturnType<
-  typeof useGetFollowingsTriplesSuspenseQuery
->
-export type GetFollowingsTriplesQueryResult = Apollo.QueryResult<
-  GetFollowingsTriplesQuery,
-  GetFollowingsTriplesQueryVariables
->
-export const GetAccountByIdDocument = {
+export const GetAccountById = {
   kind: "Document",
   definitions: [
     {
@@ -44635,82 +50121,7 @@ export const GetAccountByIdDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAccountByIdQuery__
- *
- * To run a query within a React component, call `useGetAccountByIdQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAccountByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAccountByIdQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetAccountByIdQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetAccountByIdQuery,
-    GetAccountByIdQueryVariables
-  > &
-    (
-      | { variables: GetAccountByIdQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetAccountByIdQuery, GetAccountByIdQueryVariables>(
-    GetAccountByIdDocument,
-    options
-  )
-}
-export function useGetAccountByIdLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAccountByIdQuery,
-    GetAccountByIdQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetAccountByIdQuery, GetAccountByIdQueryVariables>(
-    GetAccountByIdDocument,
-    options
-  )
-}
-export function useGetAccountByIdSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAccountByIdQuery,
-        GetAccountByIdQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAccountByIdQuery,
-    GetAccountByIdQueryVariables
-  >(GetAccountByIdDocument, options)
-}
-export type GetAccountByIdQueryHookResult = ReturnType<
-  typeof useGetAccountByIdQuery
->
-export type GetAccountByIdLazyQueryHookResult = ReturnType<
-  typeof useGetAccountByIdLazyQuery
->
-export type GetAccountByIdSuspenseQueryHookResult = ReturnType<
-  typeof useGetAccountByIdSuspenseQuery
->
-export type GetAccountByIdQueryResult = Apollo.QueryResult<
-  GetAccountByIdQuery,
-  GetAccountByIdQueryVariables
->
-export const GetListsDocument = {
+export const GetLists = {
   kind: "Document",
   definitions: [
     {
@@ -44836,70 +50247,7 @@ export const GetListsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListsQuery__
- *
- * To run a query within a React component, call `useGetListsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListsQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetListsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetListsQuery, GetListsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetListsQuery, GetListsQueryVariables>(
-    GetListsDocument,
-    options
-  )
-}
-export function useGetListsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListsQuery,
-    GetListsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetListsQuery, GetListsQueryVariables>(
-    GetListsDocument,
-    options
-  )
-}
-export function useGetListsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetListsQuery, GetListsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetListsQuery, GetListsQueryVariables>(
-    GetListsDocument,
-    options
-  )
-}
-export type GetListsQueryHookResult = ReturnType<typeof useGetListsQuery>
-export type GetListsLazyQueryHookResult = ReturnType<
-  typeof useGetListsLazyQuery
->
-export type GetListsSuspenseQueryHookResult = ReturnType<
-  typeof useGetListsSuspenseQuery
->
-export type GetListsQueryResult = Apollo.QueryResult<
-  GetListsQuery,
-  GetListsQueryVariables
->
-export const GetListItemsDocument = {
+export const GetListItems = {
   kind: "Document",
   definitions: [
     {
@@ -45762,79 +51110,7 @@ export const GetListItemsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListItemsQuery__
- *
- * To run a query within a React component, call `useGetListItemsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListItemsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListItemsQuery({
- *   variables: {
- *      predicateId: // value for 'predicateId'
- *      objectId: // value for 'objectId'
- *   },
- * });
- */
-export function useGetListItemsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetListItemsQuery,
-    GetListItemsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetListItemsQuery, GetListItemsQueryVariables>(
-    GetListItemsDocument,
-    options
-  )
-}
-export function useGetListItemsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListItemsQuery,
-    GetListItemsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetListItemsQuery, GetListItemsQueryVariables>(
-    GetListItemsDocument,
-    options
-  )
-}
-export function useGetListItemsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetListItemsQuery,
-        GetListItemsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetListItemsQuery, GetListItemsQueryVariables>(
-    GetListItemsDocument,
-    options
-  )
-}
-export type GetListItemsQueryHookResult = ReturnType<
-  typeof useGetListItemsQuery
->
-export type GetListItemsLazyQueryHookResult = ReturnType<
-  typeof useGetListItemsLazyQuery
->
-export type GetListItemsSuspenseQueryHookResult = ReturnType<
-  typeof useGetListItemsSuspenseQuery
->
-export type GetListItemsQueryResult = Apollo.QueryResult<
-  GetListItemsQuery,
-  GetListItemsQueryVariables
->
-export const GetListDetailsDocument = {
+export const GetListDetails = {
   kind: "Document",
   definitions: [
     {
@@ -46332,82 +51608,7 @@ export const GetListDetailsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListDetailsQuery__
- *
- * To run a query within a React component, call `useGetListDetailsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListDetailsQuery({
- *   variables: {
- *      globalWhere: // value for 'globalWhere'
- *      tagPredicateId: // value for 'tagPredicateId'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *   },
- * });
- */
-export function useGetListDetailsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetListDetailsQuery,
-    GetListDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetListDetailsQuery, GetListDetailsQueryVariables>(
-    GetListDetailsDocument,
-    options
-  )
-}
-export function useGetListDetailsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListDetailsQuery,
-    GetListDetailsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetListDetailsQuery, GetListDetailsQueryVariables>(
-    GetListDetailsDocument,
-    options
-  )
-}
-export function useGetListDetailsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetListDetailsQuery,
-        GetListDetailsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetListDetailsQuery,
-    GetListDetailsQueryVariables
-  >(GetListDetailsDocument, options)
-}
-export type GetListDetailsQueryHookResult = ReturnType<
-  typeof useGetListDetailsQuery
->
-export type GetListDetailsLazyQueryHookResult = ReturnType<
-  typeof useGetListDetailsLazyQuery
->
-export type GetListDetailsSuspenseQueryHookResult = ReturnType<
-  typeof useGetListDetailsSuspenseQuery
->
-export type GetListDetailsQueryResult = Apollo.QueryResult<
-  GetListDetailsQuery,
-  GetListDetailsQueryVariables
->
-export const GetListDetailsWithPositionDocument = {
+export const GetListDetailsWithPosition = {
   kind: "Document",
   definitions: [
     {
@@ -46985,83 +52186,7 @@ export const GetListDetailsWithPositionDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListDetailsWithPositionQuery__
- *
- * To run a query within a React component, call `useGetListDetailsWithPositionQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListDetailsWithPositionQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListDetailsWithPositionQuery({
- *   variables: {
- *      globalWhere: // value for 'globalWhere'
- *      tagPredicateId: // value for 'tagPredicateId'
- *      address: // value for 'address'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *   },
- * });
- */
-export function useGetListDetailsWithPositionQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetListDetailsWithPositionQuery,
-    GetListDetailsWithPositionQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetListDetailsWithPositionQuery,
-    GetListDetailsWithPositionQueryVariables
-  >(GetListDetailsWithPositionDocument, options)
-}
-export function useGetListDetailsWithPositionLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListDetailsWithPositionQuery,
-    GetListDetailsWithPositionQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetListDetailsWithPositionQuery,
-    GetListDetailsWithPositionQueryVariables
-  >(GetListDetailsWithPositionDocument, options)
-}
-export function useGetListDetailsWithPositionSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetListDetailsWithPositionQuery,
-        GetListDetailsWithPositionQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetListDetailsWithPositionQuery,
-    GetListDetailsWithPositionQueryVariables
-  >(GetListDetailsWithPositionDocument, options)
-}
-export type GetListDetailsWithPositionQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithPositionQuery
->
-export type GetListDetailsWithPositionLazyQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithPositionLazyQuery
->
-export type GetListDetailsWithPositionSuspenseQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithPositionSuspenseQuery
->
-export type GetListDetailsWithPositionQueryResult = Apollo.QueryResult<
-  GetListDetailsWithPositionQuery,
-  GetListDetailsWithPositionQueryVariables
->
-export const GetListDetailsWithUserDocument = {
+export const GetListDetailsWithUser = {
   kind: "Document",
   definitions: [
     {
@@ -48127,84 +53252,7 @@ export const GetListDetailsWithUserDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListDetailsWithUserQuery__
- *
- * To run a query within a React component, call `useGetListDetailsWithUserQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListDetailsWithUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListDetailsWithUserQuery({
- *   variables: {
- *      globalWhere: // value for 'globalWhere'
- *      userWhere: // value for 'userWhere'
- *      tagPredicateId: // value for 'tagPredicateId'
- *      address: // value for 'address'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *   },
- * });
- */
-export function useGetListDetailsWithUserQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetListDetailsWithUserQuery,
-    GetListDetailsWithUserQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetListDetailsWithUserQuery,
-    GetListDetailsWithUserQueryVariables
-  >(GetListDetailsWithUserDocument, options)
-}
-export function useGetListDetailsWithUserLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListDetailsWithUserQuery,
-    GetListDetailsWithUserQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetListDetailsWithUserQuery,
-    GetListDetailsWithUserQueryVariables
-  >(GetListDetailsWithUserDocument, options)
-}
-export function useGetListDetailsWithUserSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetListDetailsWithUserQuery,
-        GetListDetailsWithUserQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetListDetailsWithUserQuery,
-    GetListDetailsWithUserQueryVariables
-  >(GetListDetailsWithUserDocument, options)
-}
-export type GetListDetailsWithUserQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithUserQuery
->
-export type GetListDetailsWithUserLazyQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithUserLazyQuery
->
-export type GetListDetailsWithUserSuspenseQueryHookResult = ReturnType<
-  typeof useGetListDetailsWithUserSuspenseQuery
->
-export type GetListDetailsWithUserQueryResult = Apollo.QueryResult<
-  GetListDetailsWithUserQuery,
-  GetListDetailsWithUserQueryVariables
->
-export const GetFeeTransfersDocument = {
+export const GetFeeTransfers = {
   kind: "Document",
   definitions: [
     {
@@ -48394,83 +53442,7 @@ export const GetFeeTransfersDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetFeeTransfersQuery__
- *
- * To run a query within a React component, call `useGetFeeTransfersQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetFeeTransfersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetFeeTransfersQuery({
- *   variables: {
- *      address: // value for 'address'
- *      cutoff_timestamp: // value for 'cutoff_timestamp'
- *   },
- * });
- */
-export function useGetFeeTransfersQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetFeeTransfersQuery,
-    GetFeeTransfersQueryVariables
-  > &
-    (
-      | { variables: GetFeeTransfersQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetFeeTransfersQuery, GetFeeTransfersQueryVariables>(
-    GetFeeTransfersDocument,
-    options
-  )
-}
-export function useGetFeeTransfersLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetFeeTransfersQuery,
-    GetFeeTransfersQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetFeeTransfersQuery,
-    GetFeeTransfersQueryVariables
-  >(GetFeeTransfersDocument, options)
-}
-export function useGetFeeTransfersSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetFeeTransfersQuery,
-        GetFeeTransfersQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetFeeTransfersQuery,
-    GetFeeTransfersQueryVariables
-  >(GetFeeTransfersDocument, options)
-}
-export type GetFeeTransfersQueryHookResult = ReturnType<
-  typeof useGetFeeTransfersQuery
->
-export type GetFeeTransfersLazyQueryHookResult = ReturnType<
-  typeof useGetFeeTransfersLazyQuery
->
-export type GetFeeTransfersSuspenseQueryHookResult = ReturnType<
-  typeof useGetFeeTransfersSuspenseQuery
->
-export type GetFeeTransfersQueryResult = Apollo.QueryResult<
-  GetFeeTransfersQuery,
-  GetFeeTransfersQueryVariables
->
-export const GetPositionsDocument = {
+export const GetPositions = {
   kind: "Document",
   definitions: [
     {
@@ -49170,81 +54142,7 @@ export const GetPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetPositionsQuery__
- *
- * To run a query within a React component, call `useGetPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPositionsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetPositionsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetPositionsQuery,
-    GetPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetPositionsQuery, GetPositionsQueryVariables>(
-    GetPositionsDocument,
-    options
-  )
-}
-export function useGetPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPositionsQuery,
-    GetPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetPositionsQuery, GetPositionsQueryVariables>(
-    GetPositionsDocument,
-    options
-  )
-}
-export function useGetPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetPositionsQuery,
-        GetPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetPositionsQuery, GetPositionsQueryVariables>(
-    GetPositionsDocument,
-    options
-  )
-}
-export type GetPositionsQueryHookResult = ReturnType<
-  typeof useGetPositionsQuery
->
-export type GetPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetPositionsLazyQuery
->
-export type GetPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetPositionsSuspenseQuery
->
-export type GetPositionsQueryResult = Apollo.QueryResult<
-  GetPositionsQuery,
-  GetPositionsQueryVariables
->
-export const GetTriplePositionsByAddressDocument = {
+export const GetTriplePositionsByAddress = {
   kind: "Document",
   definitions: [
     {
@@ -50191,86 +55089,7 @@ export const GetTriplePositionsByAddressDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTriplePositionsByAddressQuery__
- *
- * To run a query within a React component, call `useGetTriplePositionsByAddressQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplePositionsByAddressQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplePositionsByAddressQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetTriplePositionsByAddressQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTriplePositionsByAddressQuery,
-    GetTriplePositionsByAddressQueryVariables
-  > &
-    (
-      | { variables: GetTriplePositionsByAddressQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetTriplePositionsByAddressQuery,
-    GetTriplePositionsByAddressQueryVariables
-  >(GetTriplePositionsByAddressDocument, options)
-}
-export function useGetTriplePositionsByAddressLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplePositionsByAddressQuery,
-    GetTriplePositionsByAddressQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTriplePositionsByAddressQuery,
-    GetTriplePositionsByAddressQueryVariables
-  >(GetTriplePositionsByAddressDocument, options)
-}
-export function useGetTriplePositionsByAddressSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTriplePositionsByAddressQuery,
-        GetTriplePositionsByAddressQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTriplePositionsByAddressQuery,
-    GetTriplePositionsByAddressQueryVariables
-  >(GetTriplePositionsByAddressDocument, options)
-}
-export type GetTriplePositionsByAddressQueryHookResult = ReturnType<
-  typeof useGetTriplePositionsByAddressQuery
->
-export type GetTriplePositionsByAddressLazyQueryHookResult = ReturnType<
-  typeof useGetTriplePositionsByAddressLazyQuery
->
-export type GetTriplePositionsByAddressSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplePositionsByAddressSuspenseQuery
->
-export type GetTriplePositionsByAddressQueryResult = Apollo.QueryResult<
-  GetTriplePositionsByAddressQuery,
-  GetTriplePositionsByAddressQueryVariables
->
-export const GetPositionsWithAggregatesDocument = {
+export const GetPositionsWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -50946,81 +55765,7 @@ export const GetPositionsWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetPositionsWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetPositionsWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPositionsWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPositionsWithAggregatesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetPositionsWithAggregatesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetPositionsWithAggregatesQuery,
-    GetPositionsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetPositionsWithAggregatesQuery,
-    GetPositionsWithAggregatesQueryVariables
-  >(GetPositionsWithAggregatesDocument, options)
-}
-export function useGetPositionsWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPositionsWithAggregatesQuery,
-    GetPositionsWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetPositionsWithAggregatesQuery,
-    GetPositionsWithAggregatesQueryVariables
-  >(GetPositionsWithAggregatesDocument, options)
-}
-export function useGetPositionsWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetPositionsWithAggregatesQuery,
-        GetPositionsWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetPositionsWithAggregatesQuery,
-    GetPositionsWithAggregatesQueryVariables
-  >(GetPositionsWithAggregatesDocument, options)
-}
-export type GetPositionsWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetPositionsWithAggregatesQuery
->
-export type GetPositionsWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetPositionsWithAggregatesLazyQuery
->
-export type GetPositionsWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetPositionsWithAggregatesSuspenseQuery
->
-export type GetPositionsWithAggregatesQueryResult = Apollo.QueryResult<
-  GetPositionsWithAggregatesQuery,
-  GetPositionsWithAggregatesQueryVariables
->
-export const GetPositionsCountDocument = {
+export const GetPositionsCount = {
   kind: "Document",
   definitions: [
     {
@@ -51091,78 +55836,7 @@ export const GetPositionsCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetPositionsCountQuery__
- *
- * To run a query within a React component, call `useGetPositionsCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPositionsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPositionsCountQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetPositionsCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetPositionsCountQuery,
-    GetPositionsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetPositionsCountQuery,
-    GetPositionsCountQueryVariables
-  >(GetPositionsCountDocument, options)
-}
-export function useGetPositionsCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPositionsCountQuery,
-    GetPositionsCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetPositionsCountQuery,
-    GetPositionsCountQueryVariables
-  >(GetPositionsCountDocument, options)
-}
-export function useGetPositionsCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetPositionsCountQuery,
-        GetPositionsCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetPositionsCountQuery,
-    GetPositionsCountQueryVariables
-  >(GetPositionsCountDocument, options)
-}
-export type GetPositionsCountQueryHookResult = ReturnType<
-  typeof useGetPositionsCountQuery
->
-export type GetPositionsCountLazyQueryHookResult = ReturnType<
-  typeof useGetPositionsCountLazyQuery
->
-export type GetPositionsCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetPositionsCountSuspenseQuery
->
-export type GetPositionsCountQueryResult = Apollo.QueryResult<
-  GetPositionsCountQuery,
-  GetPositionsCountQueryVariables
->
-export const GetPositionDocument = {
+export const GetPosition = {
   kind: "Document",
   definitions: [
     {
@@ -51762,80 +56436,7 @@ export const GetPositionDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetPositionQuery__
- *
- * To run a query within a React component, call `useGetPositionQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPositionQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPositionQuery({
- *   variables: {
- *      positionId: // value for 'positionId'
- *   },
- * });
- */
-export function useGetPositionQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetPositionQuery,
-    GetPositionQueryVariables
-  > &
-    (
-      | { variables: GetPositionQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetPositionQuery, GetPositionQueryVariables>(
-    GetPositionDocument,
-    options
-  )
-}
-export function useGetPositionLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPositionQuery,
-    GetPositionQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetPositionQuery, GetPositionQueryVariables>(
-    GetPositionDocument,
-    options
-  )
-}
-export function useGetPositionSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetPositionQuery,
-        GetPositionQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetPositionQuery, GetPositionQueryVariables>(
-    GetPositionDocument,
-    options
-  )
-}
-export type GetPositionQueryHookResult = ReturnType<typeof useGetPositionQuery>
-export type GetPositionLazyQueryHookResult = ReturnType<
-  typeof useGetPositionLazyQuery
->
-export type GetPositionSuspenseQueryHookResult = ReturnType<
-  typeof useGetPositionSuspenseQuery
->
-export type GetPositionQueryResult = Apollo.QueryResult<
-  GetPositionQuery,
-  GetPositionQueryVariables
->
-export const GetPositionsCountByTypeDocument = {
+export const GetPositionsCountByType = {
   kind: "Document",
   definitions: [
     {
@@ -51928,78 +56529,7 @@ export const GetPositionsCountByTypeDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetPositionsCountByTypeQuery__
- *
- * To run a query within a React component, call `useGetPositionsCountByTypeQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPositionsCountByTypeQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPositionsCountByTypeQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetPositionsCountByTypeQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetPositionsCountByTypeQuery,
-    GetPositionsCountByTypeQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetPositionsCountByTypeQuery,
-    GetPositionsCountByTypeQueryVariables
-  >(GetPositionsCountByTypeDocument, options)
-}
-export function useGetPositionsCountByTypeLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetPositionsCountByTypeQuery,
-    GetPositionsCountByTypeQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetPositionsCountByTypeQuery,
-    GetPositionsCountByTypeQueryVariables
-  >(GetPositionsCountByTypeDocument, options)
-}
-export function useGetPositionsCountByTypeSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetPositionsCountByTypeQuery,
-        GetPositionsCountByTypeQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetPositionsCountByTypeQuery,
-    GetPositionsCountByTypeQueryVariables
-  >(GetPositionsCountByTypeDocument, options)
-}
-export type GetPositionsCountByTypeQueryHookResult = ReturnType<
-  typeof useGetPositionsCountByTypeQuery
->
-export type GetPositionsCountByTypeLazyQueryHookResult = ReturnType<
-  typeof useGetPositionsCountByTypeLazyQuery
->
-export type GetPositionsCountByTypeSuspenseQueryHookResult = ReturnType<
-  typeof useGetPositionsCountByTypeSuspenseQuery
->
-export type GetPositionsCountByTypeQueryResult = Apollo.QueryResult<
-  GetPositionsCountByTypeQuery,
-  GetPositionsCountByTypeQueryVariables
->
-export const GetSignalsDocument = {
+export const GetSignals = {
   kind: "Document",
   definitions: [
     {
@@ -53148,76 +57678,7 @@ export const GetSignalsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetSignalsQuery__
- *
- * To run a query within a React component, call `useGetSignalsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetSignalsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetSignalsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      addresses: // value for 'addresses'
- *   },
- * });
- */
-export function useGetSignalsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetSignalsQuery,
-    GetSignalsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetSignalsQuery, GetSignalsQueryVariables>(
-    GetSignalsDocument,
-    options
-  )
-}
-export function useGetSignalsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetSignalsQuery,
-    GetSignalsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetSignalsQuery, GetSignalsQueryVariables>(
-    GetSignalsDocument,
-    options
-  )
-}
-export function useGetSignalsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetSignalsQuery, GetSignalsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetSignalsQuery, GetSignalsQueryVariables>(
-    GetSignalsDocument,
-    options
-  )
-}
-export type GetSignalsQueryHookResult = ReturnType<typeof useGetSignalsQuery>
-export type GetSignalsLazyQueryHookResult = ReturnType<
-  typeof useGetSignalsLazyQuery
->
-export type GetSignalsSuspenseQueryHookResult = ReturnType<
-  typeof useGetSignalsSuspenseQuery
->
-export type GetSignalsQueryResult = Apollo.QueryResult<
-  GetSignalsQuery,
-  GetSignalsQueryVariables
->
-export const GetStatsDocument = {
+export const GetStats = {
   kind: "Document",
   definitions: [
     {
@@ -53265,69 +57726,7 @@ export const GetStatsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetStatsQuery__
- *
- * To run a query within a React component, call `useGetStatsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetStatsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetStatsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetStatsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetStatsQuery, GetStatsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetStatsQuery, GetStatsQueryVariables>(
-    GetStatsDocument,
-    options
-  )
-}
-export function useGetStatsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetStatsQuery,
-    GetStatsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetStatsQuery, GetStatsQueryVariables>(
-    GetStatsDocument,
-    options
-  )
-}
-export function useGetStatsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetStatsQuery, GetStatsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetStatsQuery, GetStatsQueryVariables>(
-    GetStatsDocument,
-    options
-  )
-}
-export type GetStatsQueryHookResult = ReturnType<typeof useGetStatsQuery>
-export type GetStatsLazyQueryHookResult = ReturnType<
-  typeof useGetStatsLazyQuery
->
-export type GetStatsSuspenseQueryHookResult = ReturnType<
-  typeof useGetStatsSuspenseQuery
->
-export type GetStatsQueryResult = Apollo.QueryResult<
-  GetStatsQuery,
-  GetStatsQueryVariables
->
-export const GetTagsDocument = {
+export const GetTags = {
   kind: "Document",
   definitions: [
     {
@@ -53902,67 +58301,7 @@ export const GetTagsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTagsQuery__
- *
- * To run a query within a React component, call `useGetTagsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTagsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTagsQuery({
- *   variables: {
- *      subjectId: // value for 'subjectId'
- *      predicateId: // value for 'predicateId'
- *   },
- * });
- */
-export function useGetTagsQuery(
-  baseOptions: Apollo.QueryHookOptions<GetTagsQuery, GetTagsQueryVariables> &
-    ({ variables: GetTagsQueryVariables; skip?: boolean } | { skip: boolean })
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTagsQuery, GetTagsQueryVariables>(
-    GetTagsDocument,
-    options
-  )
-}
-export function useGetTagsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<GetTagsQuery, GetTagsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetTagsQuery, GetTagsQueryVariables>(
-    GetTagsDocument,
-    options
-  )
-}
-export function useGetTagsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetTagsQuery, GetTagsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetTagsQuery, GetTagsQueryVariables>(
-    GetTagsDocument,
-    options
-  )
-}
-export type GetTagsQueryHookResult = ReturnType<typeof useGetTagsQuery>
-export type GetTagsLazyQueryHookResult = ReturnType<typeof useGetTagsLazyQuery>
-export type GetTagsSuspenseQueryHookResult = ReturnType<
-  typeof useGetTagsSuspenseQuery
->
-export type GetTagsQueryResult = Apollo.QueryResult<
-  GetTagsQuery,
-  GetTagsQueryVariables
->
-export const GetTagsCustomDocument = {
+export const GetTagsCustom = {
   kind: "Document",
   definitions: [
     {
@@ -54460,78 +58799,7 @@ export const GetTagsCustomDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTagsCustomQuery__
- *
- * To run a query within a React component, call `useGetTagsCustomQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTagsCustomQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTagsCustomQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetTagsCustomQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTagsCustomQuery,
-    GetTagsCustomQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTagsCustomQuery, GetTagsCustomQueryVariables>(
-    GetTagsCustomDocument,
-    options
-  )
-}
-export function useGetTagsCustomLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTagsCustomQuery,
-    GetTagsCustomQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetTagsCustomQuery, GetTagsCustomQueryVariables>(
-    GetTagsCustomDocument,
-    options
-  )
-}
-export function useGetTagsCustomSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTagsCustomQuery,
-        GetTagsCustomQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTagsCustomQuery,
-    GetTagsCustomQueryVariables
-  >(GetTagsCustomDocument, options)
-}
-export type GetTagsCustomQueryHookResult = ReturnType<
-  typeof useGetTagsCustomQuery
->
-export type GetTagsCustomLazyQueryHookResult = ReturnType<
-  typeof useGetTagsCustomLazyQuery
->
-export type GetTagsCustomSuspenseQueryHookResult = ReturnType<
-  typeof useGetTagsCustomSuspenseQuery
->
-export type GetTagsCustomQueryResult = Apollo.QueryResult<
-  GetTagsCustomQuery,
-  GetTagsCustomQueryVariables
->
-export const GetListsTagsDocument = {
+export const GetListsTags = {
   kind: "Document",
   definitions: [
     {
@@ -54799,82 +59067,7 @@ export const GetListsTagsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetListsTagsQuery__
- *
- * To run a query within a React component, call `useGetListsTagsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetListsTagsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetListsTagsQuery({
- *   variables: {
- *      where: // value for 'where'
- *      triplesWhere: // value for 'triplesWhere'
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *   },
- * });
- */
-export function useGetListsTagsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetListsTagsQuery,
-    GetListsTagsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetListsTagsQuery, GetListsTagsQueryVariables>(
-    GetListsTagsDocument,
-    options
-  )
-}
-export function useGetListsTagsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetListsTagsQuery,
-    GetListsTagsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetListsTagsQuery, GetListsTagsQueryVariables>(
-    GetListsTagsDocument,
-    options
-  )
-}
-export function useGetListsTagsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetListsTagsQuery,
-        GetListsTagsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetListsTagsQuery, GetListsTagsQueryVariables>(
-    GetListsTagsDocument,
-    options
-  )
-}
-export type GetListsTagsQueryHookResult = ReturnType<
-  typeof useGetListsTagsQuery
->
-export type GetListsTagsLazyQueryHookResult = ReturnType<
-  typeof useGetListsTagsLazyQuery
->
-export type GetListsTagsSuspenseQueryHookResult = ReturnType<
-  typeof useGetListsTagsSuspenseQuery
->
-export type GetListsTagsQueryResult = Apollo.QueryResult<
-  GetListsTagsQuery,
-  GetListsTagsQueryVariables
->
-export const GetTaggedObjectsDocument = {
+export const GetTaggedObjects = {
   kind: "Document",
   definitions: [
     {
@@ -55199,311 +59392,7 @@ export const GetTaggedObjectsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTaggedObjectsQuery__
- *
- * To run a query within a React component, call `useGetTaggedObjectsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTaggedObjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTaggedObjectsQuery({
- *   variables: {
- *      objectId: // value for 'objectId'
- *      predicateId: // value for 'predicateId'
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetTaggedObjectsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTaggedObjectsQuery,
-    GetTaggedObjectsQueryVariables
-  > &
-    (
-      | { variables: GetTaggedObjectsQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTaggedObjectsQuery, GetTaggedObjectsQueryVariables>(
-    GetTaggedObjectsDocument,
-    options
-  )
-}
-export function useGetTaggedObjectsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTaggedObjectsQuery,
-    GetTaggedObjectsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTaggedObjectsQuery,
-    GetTaggedObjectsQueryVariables
-  >(GetTaggedObjectsDocument, options)
-}
-export function useGetTaggedObjectsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTaggedObjectsQuery,
-        GetTaggedObjectsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTaggedObjectsQuery,
-    GetTaggedObjectsQueryVariables
-  >(GetTaggedObjectsDocument, options)
-}
-export type GetTaggedObjectsQueryHookResult = ReturnType<
-  typeof useGetTaggedObjectsQuery
->
-export type GetTaggedObjectsLazyQueryHookResult = ReturnType<
-  typeof useGetTaggedObjectsLazyQuery
->
-export type GetTaggedObjectsSuspenseQueryHookResult = ReturnType<
-  typeof useGetTaggedObjectsSuspenseQuery
->
-export type GetTaggedObjectsQueryResult = Apollo.QueryResult<
-  GetTaggedObjectsQuery,
-  GetTaggedObjectsQueryVariables
->
-export const GetTriplesByCreatorDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "GetTriplesByCreator" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: {
-            kind: "Variable",
-            name: { kind: "Name", value: "address" }
-          },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } }
-        }
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "triples" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "where" },
-                value: {
-                  kind: "ObjectValue",
-                  fields: [
-                    {
-                      kind: "ObjectField",
-                      name: { kind: "Name", value: "creator_id" },
-                      value: {
-                        kind: "ObjectValue",
-                        fields: [
-                          {
-                            kind: "ObjectField",
-                            name: { kind: "Name", value: "_eq" },
-                            value: {
-                              kind: "Variable",
-                              name: { kind: "Name", value: "address" }
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "Field", name: { kind: "Name", value: "term_id" } },
-                { kind: "Field", name: { kind: "Name", value: "creator_id" } },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "subject" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      {
-                        kind: "Field",
-                        name: { kind: "Name", value: "term_id" }
-                      },
-                      { kind: "Field", name: { kind: "Name", value: "label" } },
-                      { kind: "Field", name: { kind: "Name", value: "image" } },
-                      { kind: "Field", name: { kind: "Name", value: "type" } }
-                    ]
-                  }
-                },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "predicate" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      {
-                        kind: "Field",
-                        name: { kind: "Name", value: "term_id" }
-                      },
-                      { kind: "Field", name: { kind: "Name", value: "label" } },
-                      { kind: "Field", name: { kind: "Name", value: "image" } },
-                      { kind: "Field", name: { kind: "Name", value: "type" } }
-                    ]
-                  }
-                },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "object" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      {
-                        kind: "Field",
-                        name: { kind: "Name", value: "term_id" }
-                      },
-                      { kind: "Field", name: { kind: "Name", value: "label" } },
-                      { kind: "Field", name: { kind: "Name", value: "image" } },
-                      { kind: "Field", name: { kind: "Name", value: "type" } }
-                    ]
-                  }
-                },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "positions_aggregate" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      {
-                        kind: "Field",
-                        name: { kind: "Name", value: "aggregate" },
-                        selectionSet: {
-                          kind: "SelectionSet",
-                          selections: [
-                            {
-                              kind: "Field",
-                              name: { kind: "Name", value: "count" }
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "counter_positions_aggregate" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      {
-                        kind: "Field",
-                        name: { kind: "Name", value: "aggregate" },
-                        selectionSet: {
-                          kind: "SelectionSet",
-                          selections: [
-                            {
-                              kind: "Field",
-                              name: { kind: "Name", value: "count" }
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ]
-} as unknown as DocumentNode
-
-/**
- * __useGetTriplesByCreatorQuery__
- *
- * To run a query within a React component, call `useGetTriplesByCreatorQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplesByCreatorQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplesByCreatorQuery({
- *   variables: {
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetTriplesByCreatorQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTriplesByCreatorQuery,
-    GetTriplesByCreatorQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetTriplesByCreatorQuery,
-    GetTriplesByCreatorQueryVariables
-  >(GetTriplesByCreatorDocument, options)
-}
-export function useGetTriplesByCreatorLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplesByCreatorQuery,
-    GetTriplesByCreatorQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTriplesByCreatorQuery,
-    GetTriplesByCreatorQueryVariables
-  >(GetTriplesByCreatorDocument, options)
-}
-export function useGetTriplesByCreatorSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTriplesByCreatorQuery,
-        GetTriplesByCreatorQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTriplesByCreatorQuery,
-    GetTriplesByCreatorQueryVariables
-  >(GetTriplesByCreatorDocument, options)
-}
-export type GetTriplesByCreatorQueryHookResult = ReturnType<
-  typeof useGetTriplesByCreatorQuery
->
-export type GetTriplesByCreatorLazyQueryHookResult = ReturnType<
-  typeof useGetTriplesByCreatorLazyQuery
->
-export type GetTriplesByCreatorSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplesByCreatorSuspenseQuery
->
-export type GetTriplesByCreatorQueryResult = Apollo.QueryResult<
-  GetTriplesByCreatorQuery,
-  GetTriplesByCreatorQueryVariables
->
-export const GetTriplesDocument = {
+export const GetTriples = {
   kind: "Document",
   definitions: [
     {
@@ -56722,76 +60611,7 @@ export const GetTriplesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTriplesQuery__
- *
- * To run a query within a React component, call `useGetTriplesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetTriplesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTriplesQuery,
-    GetTriplesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTriplesQuery, GetTriplesQueryVariables>(
-    GetTriplesDocument,
-    options
-  )
-}
-export function useGetTriplesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplesQuery,
-    GetTriplesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetTriplesQuery, GetTriplesQueryVariables>(
-    GetTriplesDocument,
-    options
-  )
-}
-export function useGetTriplesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetTriplesQuery, GetTriplesQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetTriplesQuery, GetTriplesQueryVariables>(
-    GetTriplesDocument,
-    options
-  )
-}
-export type GetTriplesQueryHookResult = ReturnType<typeof useGetTriplesQuery>
-export type GetTriplesLazyQueryHookResult = ReturnType<
-  typeof useGetTriplesLazyQuery
->
-export type GetTriplesSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplesSuspenseQuery
->
-export type GetTriplesQueryResult = Apollo.QueryResult<
-  GetTriplesQuery,
-  GetTriplesQueryVariables
->
-export const GetTriplesWithAggregatesDocument = {
+export const GetTriplesWithAggregates = {
   kind: "Document",
   definitions: [
     {
@@ -57999,81 +61819,7 @@ export const GetTriplesWithAggregatesDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTriplesWithAggregatesQuery__
- *
- * To run a query within a React component, call `useGetTriplesWithAggregatesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplesWithAggregatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplesWithAggregatesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetTriplesWithAggregatesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTriplesWithAggregatesQuery,
-    GetTriplesWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetTriplesWithAggregatesQuery,
-    GetTriplesWithAggregatesQueryVariables
-  >(GetTriplesWithAggregatesDocument, options)
-}
-export function useGetTriplesWithAggregatesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplesWithAggregatesQuery,
-    GetTriplesWithAggregatesQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTriplesWithAggregatesQuery,
-    GetTriplesWithAggregatesQueryVariables
-  >(GetTriplesWithAggregatesDocument, options)
-}
-export function useGetTriplesWithAggregatesSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTriplesWithAggregatesQuery,
-        GetTriplesWithAggregatesQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTriplesWithAggregatesQuery,
-    GetTriplesWithAggregatesQueryVariables
-  >(GetTriplesWithAggregatesDocument, options)
-}
-export type GetTriplesWithAggregatesQueryHookResult = ReturnType<
-  typeof useGetTriplesWithAggregatesQuery
->
-export type GetTriplesWithAggregatesLazyQueryHookResult = ReturnType<
-  typeof useGetTriplesWithAggregatesLazyQuery
->
-export type GetTriplesWithAggregatesSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplesWithAggregatesSuspenseQuery
->
-export type GetTriplesWithAggregatesQueryResult = Apollo.QueryResult<
-  GetTriplesWithAggregatesQuery,
-  GetTriplesWithAggregatesQueryVariables
->
-export const GetTriplesCountDocument = {
+export const GetTriplesCount = {
   kind: "Document",
   definitions: [
     {
@@ -58131,78 +61877,7 @@ export const GetTriplesCountDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTriplesCountQuery__
- *
- * To run a query within a React component, call `useGetTriplesCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplesCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplesCountQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetTriplesCountQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTriplesCountQuery,
-    GetTriplesCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTriplesCountQuery, GetTriplesCountQueryVariables>(
-    GetTriplesCountDocument,
-    options
-  )
-}
-export function useGetTriplesCountLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplesCountQuery,
-    GetTriplesCountQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTriplesCountQuery,
-    GetTriplesCountQueryVariables
-  >(GetTriplesCountDocument, options)
-}
-export function useGetTriplesCountSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTriplesCountQuery,
-        GetTriplesCountQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTriplesCountQuery,
-    GetTriplesCountQueryVariables
-  >(GetTriplesCountDocument, options)
-}
-export type GetTriplesCountQueryHookResult = ReturnType<
-  typeof useGetTriplesCountQuery
->
-export type GetTriplesCountLazyQueryHookResult = ReturnType<
-  typeof useGetTriplesCountLazyQuery
->
-export type GetTriplesCountSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplesCountSuspenseQuery
->
-export type GetTriplesCountQueryResult = Apollo.QueryResult<
-  GetTriplesCountQuery,
-  GetTriplesCountQueryVariables
->
-export const GetTripleDocument = {
+export const GetTriple = {
   kind: "Document",
   definitions: [
     {
@@ -59337,74 +63012,7 @@ export const GetTripleDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTripleQuery__
- *
- * To run a query within a React component, call `useGetTripleQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTripleQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTripleQuery({
- *   variables: {
- *      tripleId: // value for 'tripleId'
- *   },
- * });
- */
-export function useGetTripleQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetTripleQuery,
-    GetTripleQueryVariables
-  > &
-    ({ variables: GetTripleQueryVariables; skip?: boolean } | { skip: boolean })
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetTripleQuery, GetTripleQueryVariables>(
-    GetTripleDocument,
-    options
-  )
-}
-export function useGetTripleLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTripleQuery,
-    GetTripleQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetTripleQuery, GetTripleQueryVariables>(
-    GetTripleDocument,
-    options
-  )
-}
-export function useGetTripleSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetTripleQuery, GetTripleQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetTripleQuery, GetTripleQueryVariables>(
-    GetTripleDocument,
-    options
-  )
-}
-export type GetTripleQueryHookResult = ReturnType<typeof useGetTripleQuery>
-export type GetTripleLazyQueryHookResult = ReturnType<
-  typeof useGetTripleLazyQuery
->
-export type GetTripleSuspenseQueryHookResult = ReturnType<
-  typeof useGetTripleSuspenseQuery
->
-export type GetTripleQueryResult = Apollo.QueryResult<
-  GetTripleQuery,
-  GetTripleQueryVariables
->
-export const GetAtomTriplesWithPositionsDocument = {
+export const GetAtomTriplesWithPositions = {
   kind: "Document",
   definitions: [
     {
@@ -59461,78 +63069,7 @@ export const GetAtomTriplesWithPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetAtomTriplesWithPositionsQuery__
- *
- * To run a query within a React component, call `useGetAtomTriplesWithPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAtomTriplesWithPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetAtomTriplesWithPositionsQuery({
- *   variables: {
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetAtomTriplesWithPositionsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetAtomTriplesWithPositionsQuery,
-    GetAtomTriplesWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetAtomTriplesWithPositionsQuery,
-    GetAtomTriplesWithPositionsQueryVariables
-  >(GetAtomTriplesWithPositionsDocument, options)
-}
-export function useGetAtomTriplesWithPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAtomTriplesWithPositionsQuery,
-    GetAtomTriplesWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetAtomTriplesWithPositionsQuery,
-    GetAtomTriplesWithPositionsQueryVariables
-  >(GetAtomTriplesWithPositionsDocument, options)
-}
-export function useGetAtomTriplesWithPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetAtomTriplesWithPositionsQuery,
-        GetAtomTriplesWithPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetAtomTriplesWithPositionsQuery,
-    GetAtomTriplesWithPositionsQueryVariables
-  >(GetAtomTriplesWithPositionsDocument, options)
-}
-export type GetAtomTriplesWithPositionsQueryHookResult = ReturnType<
-  typeof useGetAtomTriplesWithPositionsQuery
->
-export type GetAtomTriplesWithPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetAtomTriplesWithPositionsLazyQuery
->
-export type GetAtomTriplesWithPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetAtomTriplesWithPositionsSuspenseQuery
->
-export type GetAtomTriplesWithPositionsQueryResult = Apollo.QueryResult<
-  GetAtomTriplesWithPositionsQuery,
-  GetAtomTriplesWithPositionsQueryVariables
->
-export const GetTriplesWithPositionsDocument = {
+export const GetTriplesWithPositions = {
   kind: "Document",
   definitions: [
     {
@@ -59918,82 +63455,7 @@ export const GetTriplesWithPositionsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetTriplesWithPositionsQuery__
- *
- * To run a query within a React component, call `useGetTriplesWithPositionsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTriplesWithPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTriplesWithPositionsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *      address: // value for 'address'
- *   },
- * });
- */
-export function useGetTriplesWithPositionsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetTriplesWithPositionsQuery,
-    GetTriplesWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<
-    GetTriplesWithPositionsQuery,
-    GetTriplesWithPositionsQueryVariables
-  >(GetTriplesWithPositionsDocument, options)
-}
-export function useGetTriplesWithPositionsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTriplesWithPositionsQuery,
-    GetTriplesWithPositionsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetTriplesWithPositionsQuery,
-    GetTriplesWithPositionsQueryVariables
-  >(GetTriplesWithPositionsDocument, options)
-}
-export function useGetTriplesWithPositionsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetTriplesWithPositionsQuery,
-        GetTriplesWithPositionsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<
-    GetTriplesWithPositionsQuery,
-    GetTriplesWithPositionsQueryVariables
-  >(GetTriplesWithPositionsDocument, options)
-}
-export type GetTriplesWithPositionsQueryHookResult = ReturnType<
-  typeof useGetTriplesWithPositionsQuery
->
-export type GetTriplesWithPositionsLazyQueryHookResult = ReturnType<
-  typeof useGetTriplesWithPositionsLazyQuery
->
-export type GetTriplesWithPositionsSuspenseQueryHookResult = ReturnType<
-  typeof useGetTriplesWithPositionsSuspenseQuery
->
-export type GetTriplesWithPositionsQueryResult = Apollo.QueryResult<
-  GetTriplesWithPositionsQuery,
-  GetTriplesWithPositionsQueryVariables
->
-export const GetVaultsDocument = {
+export const GetVaults = {
   kind: "Document",
   definitions: [
     {
@@ -60269,73 +63731,7 @@ export const GetVaultsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetVaultsQuery__
- *
- * To run a query within a React component, call `useGetVaultsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetVaultsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetVaultsQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *      offset: // value for 'offset'
- *      orderBy: // value for 'orderBy'
- *      where: // value for 'where'
- *   },
- * });
- */
-export function useGetVaultsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetVaultsQuery, GetVaultsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetVaultsQuery, GetVaultsQueryVariables>(
-    GetVaultsDocument,
-    options
-  )
-}
-export function useGetVaultsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetVaultsQuery,
-    GetVaultsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetVaultsQuery, GetVaultsQueryVariables>(
-    GetVaultsDocument,
-    options
-  )
-}
-export function useGetVaultsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetVaultsQuery, GetVaultsQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetVaultsQuery, GetVaultsQueryVariables>(
-    GetVaultsDocument,
-    options
-  )
-}
-export type GetVaultsQueryHookResult = ReturnType<typeof useGetVaultsQuery>
-export type GetVaultsLazyQueryHookResult = ReturnType<
-  typeof useGetVaultsLazyQuery
->
-export type GetVaultsSuspenseQueryHookResult = ReturnType<
-  typeof useGetVaultsSuspenseQuery
->
-export type GetVaultsQueryResult = Apollo.QueryResult<
-  GetVaultsQuery,
-  GetVaultsQueryVariables
->
-export const GetVaultDocument = {
+export const GetVault = {
   kind: "Document",
   definitions: [
     {
@@ -60535,72 +63931,7 @@ export const GetVaultDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useGetVaultQuery__
- *
- * To run a query within a React component, call `useGetVaultQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetVaultQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetVaultQuery({
- *   variables: {
- *      termId: // value for 'termId'
- *      curveId: // value for 'curveId'
- *   },
- * });
- */
-export function useGetVaultQuery(
-  baseOptions: Apollo.QueryHookOptions<GetVaultQuery, GetVaultQueryVariables> &
-    ({ variables: GetVaultQueryVariables; skip?: boolean } | { skip: boolean })
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetVaultQuery, GetVaultQueryVariables>(
-    GetVaultDocument,
-    options
-  )
-}
-export function useGetVaultLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetVaultQuery,
-    GetVaultQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetVaultQuery, GetVaultQueryVariables>(
-    GetVaultDocument,
-    options
-  )
-}
-export function useGetVaultSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GetVaultQuery, GetVaultQueryVariables>
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions }
-  return Apollo.useSuspenseQuery<GetVaultQuery, GetVaultQueryVariables>(
-    GetVaultDocument,
-    options
-  )
-}
-export type GetVaultQueryHookResult = ReturnType<typeof useGetVaultQuery>
-export type GetVaultLazyQueryHookResult = ReturnType<
-  typeof useGetVaultLazyQuery
->
-export type GetVaultSuspenseQueryHookResult = ReturnType<
-  typeof useGetVaultSuspenseQuery
->
-export type GetVaultQueryResult = Apollo.QueryResult<
-  GetVaultQuery,
-  GetVaultQueryVariables
->
-export const EventsDocument = {
+export const Events = {
   kind: "Document",
   definitions: [
     {
@@ -61574,42 +64905,3 @@ export const EventsDocument = {
     }
   ]
 } as unknown as DocumentNode
-
-/**
- * __useEventsSubscription__
- *
- * To run a query within a React component, call `useEventsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useEventsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useEventsSubscription({
- *   variables: {
- *      addresses: // value for 'addresses'
- *      limit: // value for 'limit'
- *   },
- * });
- */
-export function useEventsSubscription(
-  baseOptions: Apollo.SubscriptionHookOptions<
-    EventsSubscription,
-    EventsSubscriptionVariables
-  > &
-    (
-      | { variables: EventsSubscriptionVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useSubscription<
-    EventsSubscription,
-    EventsSubscriptionVariables
-  >(EventsDocument, options)
-}
-export type EventsSubscriptionHookResult = ReturnType<
-  typeof useEventsSubscription
->
-export type EventsSubscriptionResult =
-  Apollo.SubscriptionResult<EventsSubscription>

--- a/src/graphql/src/queries/get-account.graphql
+++ b/src/graphql/src/queries/get-account.graphql
@@ -1,0 +1,7 @@
+query GetAccountById($id: String!) {
+  account(id: $id) {
+    id
+    label
+    image
+  }
+}

--- a/src/graphql_old/src/queries/get-account.graphql
+++ b/src/graphql_old/src/queries/get-account.graphql
@@ -1,7 +1,0 @@
-query GetAccountById($id: String!) {
-  account(id: $id) {
-    id
-    label
-    image
-  }
-}


### PR DESCRIPTION
Insures the query uses account(id: $id) format, compatible with the latest API.

Validated against the 1.5 endpoint (/v1/graphql) using Apollo Sandbox.

No changes needed to the returned fields (id, label, image) — they remain valid.

Creating the getAccountById query